### PR TITLE
chore(security): add dependabot + auto-merge workflows

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,13 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+      time: "09:00"
+      timezone: Asia/Tokyo
+    open-pull-requests-limit: 3
+    commit-message:
+      prefix: chore(ci)
+      include: scope

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,28 @@
+name: Dependabot Auto-Merge
+
+on: pull_request_target
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  auto-merge:
+    name: auto-merge patch+minor
+    if: github.actor == 'dependabot[bot]'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Fetch Dependabot metadata
+        id: meta
+        uses: dependabot/fetch-metadata@v2
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Enable auto-merge for patch+minor updates
+        if: |
+          steps.meta.outputs.update-type == 'version-update:semver-patch' ||
+          steps.meta.outputs.update-type == 'version-update:semver-minor'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
+        run: gh pr merge --auto --squash "$PR_URL"


### PR DESCRIPTION
## Summary

Security baseline 横展開 (B1・CEO Go 2026-05-09・一括) — willink-claude-kit 用に最小構成。

- `.github/dependabot.yml`: github-actions の weekly 更新 (Asia/Tokyo Mon 09:00)
- `.github/workflows/dependabot-auto-merge.yml`: dependabot の patch+minor を自動 merge

## Note: なぜ audit / codeql を入れないか

claude-kit は **markdown only OSS** (`agents/`, `commands/`, `docs/`, `skills/` 等)。`package.json` も `pubspec.yaml` も無いため:

- `pnpm audit` 対象なし → audit.yml 不適用
- javascript-typescript ソースなし → CodeQL 不適用

将来 `scripts/` に shell scripts が増えたら shellcheck workflow 追加検討。

## Test plan
- [x] `.github/dependabot.yml` schema valid (version: 2)
- [x] auto-merge workflow は dependabot bot のみ trigger
- [ ] CEO レビュー → merge