### PR TITLE
docs: WordPress/PHP を documented-unverified に整理 (#11)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes follow [Keep a Changelog](https://keepachangelog.com/en/1.1.
 ## [Unreleased]
 
 ### Changed
+- WordPress/PHP の対象スタック表現を整理 (#11) — `docs/known-stack-coverage.md` で WordPress+PHP を「explicitly out of scope」から「📝 documented, unverified」へ再定義し、利用者が期待できる支援レベル（agent 規約・dev-tester ゲート・standards は documented だが end-to-end 未検証 = best-effort）を明文化。`docs/stack-specific-notes.md` の WordPress 節冒頭に同 status の caveat を追記。coverage の SOP 参照に含まれていた内部パスは除去
 - `docs/verification-protocol.md` を v1.0 後の継続評価手順に更新 (#13) — 0.1.x 採用判断の基準・フレームは「歴史的経緯」に凍結し、v1.1 繰り越し指標（MEMORY ≥ 5 / context 1.3x / 致命的失敗 0）と stack promotion の記録様式を現行化。promotion 基準の正本は `docs/known-stack-coverage.md` のまま（重複定義しない）
 - dev-reviewer memory の path と auto-write 条件を実態に合わせて整理 (#12) — 正本は `.claude/agent-memory/dev-reviewer/MEMORY.md`（全プラットフォーム共有）のまま、plugin install 時の auto-write が plugin 名前空間付き `.claude/agent-memory/willink-claude-kit-dev-reviewer/` に着地する実測事実と発火条件（`/build` 内のみ・standalone `/agents` では発火しない = 既知制約）を README / agent prompt / adoption guides に明文化。consolidation 手順を adoption-guide §3.2 に追加
 

--- a/docs/known-stack-coverage.md
+++ b/docs/known-stack-coverage.md
@@ -90,14 +90,40 @@ verified 4-stack matrix in this document.
 
 ---
 
+## WordPress and PHP support level
+
+Status: **📝 documented, unverified**.
+
+WordPress + PHP is **not** an out-of-scope stack, but it is **not a verified
+kit lane** either. The kit ships first-party guidance for it — agent stack
+conventions (`dev-explorer`), quality-gate commands (`dev-tester`), coding
+standards (`dev-standards`), and `docs/stack-specific-notes.md` — yet **no
+production-shaped task has been driven through the kit on a WordPress repo**,
+so there is no verification evidence behind that guidance.
+
+**Support level a WordPress/PHP adopter can expect at v1.0:**
+
+- ✅ The agents *load* WordPress/PHP conventions and `dev-tester` knows the
+  `composer lint` / `phpstan` / PHPUnit gate sequence.
+- ✅ Coding-standards and stack-notes guidance (security boundaries,
+  `wp_unslash()` / `sanitize_*()` / nonce, version constraints) is documented.
+- 🟡 None of the above is verified end-to-end. Treat it as **best-effort,
+  unverified** — the same caveat as an `🟡 install-only` stack, plus the
+  review surface itself is JS/TS-centric, so PHP-specific findings depth is
+  lower than for a `✅ verified` lane.
+- ❌ There is no near-term plan to promote WordPress/PHP to `✅ verified`; the
+  kit's review surface intentionally stays JS/TS-centric.
+
+This status is reviewed each minor release. Open a discussion if a real
+adoption need would justify a verified PHP lane.
+
+---
+
 ## Stacks explicitly out of scope at v1.0
 
 The following stacks are intentionally **not** part of the v1.0 coverage
-goal and have no near-term promotion plan:
+goal, ship **no** kit guidance, and have no promotion plan:
 
-- **WordPress + PHP** — covered by an internal SOP (`assets/knowledge/2026-05-10-esperanza-ds-operational-policy.md`),
-  not by the kit. The kit's review surface is JS/TS-centric and adding PHP
-  parsing depth would diverge the agents.
 - **Static site generators (Hugo, Jekyll, etc.)** — too narrow a review
   surface to justify a kit lane.
 - **Mobile-only repositories without Cloud Functions / backend** — would

--- a/docs/stack-specific-notes.md
+++ b/docs/stack-specific-notes.md
@@ -69,6 +69,10 @@ flutter build ios     # or appbundle / web
 
 ## WordPress + PHP
 
+> **支援レベル: 📝 documented, unverified**。本セクションは first-party guidance だが、
+> kit を WordPress repo に対して end-to-end で検証した実績はない（best-effort）。
+> 詳細は [`known-stack-coverage.md`](known-stack-coverage.md#wordpress-and-php-support-level) を参照。
+
 ### dev-tester が呼ぶコマンド
 ```bash
 composer install


### PR DESCRIPTION
Closes #11

## 概要
対象スタック定義における WordPress/PHP の扱いの矛盾を解消。`docs/known-stack-coverage.md` が「explicitly out of scope」（無支援の含意）と書く一方、agents / dev-standards / stack-notes は WordPress guidance を ship しており、利用者から見て支援レベルが不明だった。

## Maker の判断点回答
issue は「正式対象から外す」か「将来対象として残す（out of scope → unsupported/unverified に整理）」の二択を提示。**後者**を採用。理由: kit は既に 4 ファイルで WordPress guidance を ship 済み（dev-explorer 規約・dev-tester ゲート・dev-standards・stack-notes）。全削除は大きな破壊的変更になる一方、coverage doc の framing を実態（documented だが未検証）に合わせる方が最小かつ正直。新ステータス **📝 documented, unverified**（既存語彙 ✅ verified / 🟡 install-only に整合）を導入し、支援レベルを明文化。

## 変更
- `docs/known-stack-coverage.md`: WordPress+PHP を out-of-scope セクションから独立した「WordPress and PHP support level」節へ。期待できる支援レベル（agent 規約 load・dev-tester ゲート・standards は documented / end-to-end 未検証 = best-effort / verified 昇格予定なし）を箇条書きで明文化。out-of-scope セクションは Hugo/Jekyll・mobile-only のみに。SOP 参照に含まれていた内部パスを除去
- `docs/stack-specific-notes.md`: WordPress 節冒頭に同 status の caveat + coverage doc への anchor link
- `CHANGELOG.md`: [Unreleased]/Changed に追記（append-only）

## Checker 結果（exit-code 判定）
| # | Check | 結果 |
|---|---|---|
| 1 | 変更ファイル = 想定 3 docs ちょうど | ✅ |
| 2 | `check_sync.py --check` exit 0 | ✅ |
| 3 | `git diff --check HEAD~1 HEAD` exit 0 | ✅ |
| 4 | CHANGELOG append-only（削除行なし） | ✅ |
| 5 | out-of-scope リストから WordPress 除外 / "documented, unverified" 存在 | ✅ |
| 6 | 支援レベル明文化（support level / 支援レベル grep hit） | ✅ |
| 7 | cross-link anchor 整合 | ✅ |
| 8 | 追加行に内部パス/顧客名なし（leak は除去側） | ✅ |
| 9 | サーフェス間の非矛盾（verified 主張なし） | ✅ |

VERDICT: PASS（9/9）/ secret scan: no hits

## 運用メモ
**auto-merge なし**。loop-dev-cycle が起票した Draft PR。人間レビュー後に手動マージしてください。