### PR TITLE
ci: check_sync.py で release バージョン整合性も検出する (#10)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes follow [Keep a Changelog](https://keepachangelog.com/en/1.1.
 
 ## [Unreleased]
 
+### Added
+- `scripts/check_sync.py` に release 整合性チェックを追加 (#10) — CHANGELOG 最新 release ヘッダと README / adoption docs のバージョン pin 例（`"willink-claude-kit@iwillink": ["x.y.z"]`）が plugin.json の version と一致するかを検証。既存 CI の `--check` がそのままガードする。過去 CHANGELOG エントリと array-vs-string の schema 反例（`["0.1.1"]` 等）は許容して false positive を回避
+
+### Fixed
+- `docs/adoption-guide.md` のバージョン pin 例が `0.1.1` のまま残っていた不整合を `2.0.0` に修正 (#10)
+
 ### Changed
 - `docs/verification-protocol.md` を v1.0 後の継続評価手順に更新 (#13) — 0.1.x 採用判断の基準・フレームは「歴史的経緯」に凍結し、v1.1 繰り越し指標（MEMORY ≥ 5 / context 1.3x / 致命的失敗 0）と stack promotion の記録様式を現行化。promotion 基準の正本は `docs/known-stack-coverage.md` のまま（重複定義しない）
 - dev-reviewer memory の path と auto-write 条件を実態に合わせて整理 (#12) — 正本は `.claude/agent-memory/dev-reviewer/MEMORY.md`（全プラットフォーム共有）のまま、plugin install 時の auto-write が plugin 名前空間付き `.claude/agent-memory/willink-claude-kit-dev-reviewer/` に着地する実測事実と発火条件（`/build` 内のみ・standalone `/agents` では発火しない = 既知制約）を README / agent prompt / adoption guides に明文化。consolidation 手順を adoption-guide §3.2 に追加

--- a/docs/adoption-guide.md
+++ b/docs/adoption-guide.md
@@ -19,7 +19,7 @@
 }
 ```
 
-バージョン pin する場合: `"willink-claude-kit@iwillink": ["0.1.1"]`
+バージョン pin する場合: `"willink-claude-kit@iwillink": ["2.0.0"]`
 
 > Phase B 検証中は **必ず pin** する（v0.x は破壊的変更ありうるため）
 

--- a/scripts/check_sync.py
+++ b/scripts/check_sync.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import argparse
 import hashlib
 import json
+import re
 import sys
 from datetime import date
 from pathlib import Path
@@ -19,6 +20,23 @@ CLAUDE_MARKETPLACE_PATH = ROOT / ".claude-plugin" / "marketplace.json"
 CODEX_PLUGIN_PATH = ROOT / ".codex-plugin" / "plugin.json"
 CODEX_BUILD_SKILL_PATH = ROOT / "skills" / "codex-build" / "SKILL.md"
 ANTIGRAVITY_BUILD_SKILL_PATH = ROOT / "skills" / "antigravity-build" / "SKILL.md"
+README_PATH = ROOT / "README.md"
+CHANGELOG_PATH = ROOT / "CHANGELOG.md"
+ADOPTION_DOC_PATHS = [
+    ROOT / "docs" / "adoption-guide.md",
+    ROOT / "docs" / "codex-adoption-guide.md",
+    ROOT / "docs" / "antigravity-adoption-guide.md",
+]
+
+# A version pin *example* always carries the plugin-name key, e.g.
+#   "willink-claude-kit@iwillink": ["2.0.0"]
+# This deliberately does NOT match bare array/string forms used to illustrate the
+# array-vs-string schema rule (e.g. `string "0.1.1"` / `array 形式 ["0.1.1"]`),
+# so those documentation counter-examples are not treated as drift.
+PLUGIN_PIN_RE = re.compile(r'"willink-claude-kit@iwillink":\s*\[\s*"(\d+\.\d+\.\d+)"\s*\]')
+# Released CHANGELOG headers look like `## [2.0.0] - 2026-06-11`; `## [Unreleased]`
+# carries no version and is intentionally skipped.
+CHANGELOG_RELEASE_RE = re.compile(r"^##\s*\[(\d+\.\d+\.\d+)\]", re.MULTILINE)
 
 REQUIRED_CANONICAL_PATHS = [
     ".claude-plugin/plugin.json",
@@ -288,6 +306,45 @@ def validate_antigravity_build_skill() -> list[str]:
     return errors
 
 
+def validate_release_consistency() -> list[str]:
+    """Catch release-version drift that hash/parity checks miss.
+
+    Guards the documented release surface against the plugin version: the latest
+    CHANGELOG release header and every version-pin example in README + adoption
+    docs must match `.claude-plugin/plugin.json`. Historical CHANGELOG entries and
+    array-vs-string schema illustrations are intentionally allowed.
+    """
+    errors: list[str] = []
+    claude_plugin = read_json(CLAUDE_PLUGIN_PATH)
+    version = claude_plugin.get("version")
+    if not isinstance(version, str):
+        return [".claude-plugin/plugin.json must define a string version"]
+
+    if not CHANGELOG_PATH.exists():
+        errors.append("Missing CHANGELOG.md")
+    else:
+        releases = CHANGELOG_RELEASE_RE.findall(CHANGELOG_PATH.read_text(encoding="utf-8"))
+        if not releases:
+            errors.append("CHANGELOG.md must contain at least one '## [x.y.z]' release header")
+        elif releases[0] != version:
+            errors.append(
+                f"CHANGELOG.md latest release '[{releases[0]}]' must match plugin version "
+                f"{version!r}. Older release headers below are allowed."
+            )
+
+    for doc in [README_PATH, *ADOPTION_DOC_PATHS]:
+        if not doc.exists():
+            continue
+        for pinned in PLUGIN_PIN_RE.findall(doc.read_text(encoding="utf-8")):
+            if pinned != version:
+                errors.append(
+                    f"{doc.relative_to(ROOT)}: version pin example '[\"{pinned}\"]' must match "
+                    f"plugin version {version!r}."
+                )
+
+    return errors
+
+
 def run_check() -> int:
     errors: list[str] = []
     try:
@@ -313,6 +370,11 @@ def run_check() -> int:
 
     try:
         errors.extend(validate_antigravity_build_skill())
+    except Exception as exc:  # noqa: BLE001
+        errors.append(str(exc))
+
+    try:
+        errors.extend(validate_release_consistency())
     except Exception as exc:  # noqa: BLE001
         errors.append(str(exc))
 


### PR DESCRIPTION
Closes #10

## 何を / なぜ
`check_sync.py` は plugin mirror と manifest hash の drift は捕まえるが、README / CHANGELOG / adoption docs が古いバージョンを主張する不整合（#9 で実害化した類のもの）は検出できなかった。release 整合性のガードを追加する。

## 変更
- `scripts/check_sync.py`: `validate_release_consistency()` を追加し `run_check()` に配線
  - CHANGELOG 最新 release ヘッダ（`## [x.y.z]`・`[Unreleased]` は skip）が plugin.json version と一致
  - README / adoption docs のバージョン pin 例 `"willink-claude-kit@iwillink": ["x.y.z"]` が一致
- `docs/adoption-guide.md`: 本チェックが検出した実在 drift（pin 例 `0.1.1` → `2.0.0`）を修正
- `CHANGELOG.md`: `[Unreleased]` に追記（append-only）

## Maker の判断点回答
- **別コマンド分離 vs check_sync.py 統合** → **統合**。既存 CI が `check_sync.py --check` を既に実行しており、新規 CI 配線なしで release 整合性が自動ガードされる。validation 群が `run_check()` に集約される既存構造とも整合。
- **docs バージョン検査の対象範囲** → 構造化された pin 例（plugin-name 接頭辞付き）と CHANGELOG 最新 release ヘッダのみ。自由文の status 行や array-vs-string の schema 反例（`string "0.1.1"` / 接頭辞なしの `["0.1.1"]`）は対象外にして false positive を回避（受け入れ条件「過去 CHANGELOG / migration note の旧バージョン表記は許容」を満たす）。

## Checker 結果（別 Agent・exit code 判定）
| # | 検査 | 結果 |
|---|---|---|
| 1 | 変更ファイル = 想定3つちょうど | PASS |
| 2 | `check_sync.py --check` exit 0 | PASS |
| 3 | `git diff --check HEAD~1 HEAD` exit 0 | PASS |
| 4a | `validate_release_consistency` 定義 + 配線（grep count=2） | PASS |
| 4b | 注入 drift `["9.9.9"]` で exit 1 検出 → 復元後 exit 0 | PASS |
| 4b | schema 反例 `["0.1.1"]` は flag されない（false positive なし） | PASS |
| 5 | CHANGELOG append-only（既存行の削除・変更なし） | PASS |
| 6 | テスト後 worktree clean | PASS |

## 運用メモ
auto-merge なし。**人間レビュー後にマージ**してください。loop-dev-cycle attempt 1/3 で PASS。