### PR TITLE
release: v2.1.0 — ループ自律生成リリース

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,10 +10,10 @@
       "source": {
         "source": "url",
         "url": "https://github.com/willink-oss/willink-claude-kit.git",
-        "ref": "willink-claude-kit--v2.0.0"
+        "ref": "willink-claude-kit--v2.1.0"
       },
       "description": "標準サブエージェント 4 本 + 5 phase /build フローを束ねた開発キット。Generator-Verifier 分離・並列探索・project-standards 拡張に対応。",
-      "version": "2.0.0",
+      "version": "2.1.0",
       "category": "development"
     }
   ]

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "willink-claude-kit",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "description": "i-Willink 標準開発エージェント基盤。dev-explorer / dev-planner / dev-tester / dev-reviewer の 4 サブエージェント + 5 phase /build コマンドを Claude Code Plugin として提供。",
   "author": {
     "name": "i-Willink合同会社",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "willink-claude-kit",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "description": "i-Willink 標準開発エージェント基盤を Codex でも使うための plugin。Claude Code 版を正本にし、Codex 向け adapter skill と同期チェックを提供する。",
   "author": {
     "name": "i-Willink合同会社",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes follow [Keep a Changelog](https://keepachangelog.com/en/1.1.
 
 ## [Unreleased]
 
+## [2.1.0] - 2026-06-13
+
+**Status**: ループ開発サイクル（ADR-009）が自律生成した初のリリース。dev サイクル 4 件（kit #13/#12/#11/#10）を Maker-Checker 分離 + 人間レビューで取り込み、deploy ステージで切り出した。docs 整合の徹底 + check_sync への release 整合性ガード追加が主軸。
+
 ### Added
 - `scripts/check_sync.py` に release 整合性チェックを追加 (#10) — CHANGELOG 最新 release ヘッダと README / adoption docs のバージョン pin 例（`"willink-claude-kit@iwillink": ["x.y.z"]`）が plugin.json の version と一致するかを検証。既存 CI の `--check` がそのままガードする。過去 CHANGELOG エントリと array-vs-string の schema 反例（`["0.1.1"]` 等）は許容して false positive を回避
 

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Claude Code / Codex / Antigravity 向け標準開発エージェント基盤。*
 }
 ```
 
-バージョン pin 例: `"willink-claude-kit@iwillink": ["2.0.0"]`
+バージョン pin 例: `"willink-claude-kit@iwillink": ["2.1.0"]`
 
 > Claude Code 公式 `settings.json` schema は `enabledPlugins.<plugin>` の値として `boolean` または `array<string>` のみ受け付ける。バージョン pin は **array 形式**で書くこと（string `"0.1.1"` は schema validator に弾かれる）。
 

--- a/codex/sync-manifest.json
+++ b/codex/sync-manifest.json
@@ -1,11 +1,11 @@
 {
   "schemaVersion": 1,
-  "updatedAt": "2026-06-12",
+  "updatedAt": "2026-06-13",
   "sourceOfTruth": "Claude Code plugin files are canonical; Codex and Antigravity files are platform adapters checked for drift.",
   "canonicalFiles": [
     {
       "path": ".claude-plugin/plugin.json",
-      "sha256": "5a6ea6cec6971fee61ad49939935e9648f3f67d6dda8582ddfc7566d12ddffcf",
+      "sha256": "5609a9fdb2a7d50e4b8f2a565897a147e2b1d49ab68b8a4427ea1a109f809cf9",
       "codexAdapters": [
         ".codex-plugin/plugin.json",
         "skills/codex-build/SKILL.md"
@@ -16,7 +16,7 @@
     },
     {
       "path": ".claude-plugin/marketplace.json",
-      "sha256": "0ab47ccf1b0fe6a50a4ea3f0bac8313779d70763da4f7680ffd537f79a2b0dd9",
+      "sha256": "a363877c4ead3f804b0afca988d5df13f1a55e947f407b744906a697de92edc2",
       "codexAdapters": [
         ".codex-plugin/plugin.json",
         "skills/codex-build/SKILL.md"

--- a/docs/adoption-guide.md
+++ b/docs/adoption-guide.md
@@ -19,7 +19,7 @@
 }
 ```
 
-バージョン pin する場合: `"willink-claude-kit@iwillink": ["2.0.0"]`
+バージョン pin する場合: `"willink-claude-kit@iwillink": ["2.1.0"]`
 
 > Phase B 検証中は **必ず pin** する（v0.x は破壊的変更ありうるため）
 


### PR DESCRIPTION
ADR-009 ループ開発サイクルが自律生成した dev 成果 4 件を束ねた **deploy ステージ**のリリース PR。

## 含まれる変更（v2.0.0 以降）
| issue | PR | 種別 | 内容 |
|---|---|---|---|
| #13 | #15 | docs | verification-protocol を v1.0 後の継続評価基準へ |
| #12 | #16 | docs | dev-reviewer memory path・auto-write 条件の整合 |
| #11 | #17 | docs | WordPress/PHP を documented-unverified へ + 顧客名 leak 除去 |
| #10 | #18 | feat(ci) | check_sync.py に release 整合性チェック追加 + 実 drift 修正 |

## metadata
- plugin.json（claude/codex）/ marketplace ref+version / README・adoption-guide pin 例 = **2.1.0** 統一
- 新設 `validate_release_consistency()` が本リリースを自己検証（`check_sync.py --check` PASS）

CEO 承認済リリース。マージ後 tag `willink-claude-kit--v2.1.0` + GitHub Release を作成します。

🤖 Generated with [Claude Code](https://claude.com/claude-code)