### PR TITLE
docs: add CLAUDE.md for internal kit development (Closes #4)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,78 @@
+# CLAUDE.md — willink-claude-kit 開発ガイド
+
+> 本 repo を **開発・保守する** Claude Code / Codex / Antigravity 向けの single source of truth。
+> 外部利用者（kit を導入する側）向けの説明は [README.md](README.md) を参照。本ファイルは
+> 内部開発者・AI agent が **この repo 自体を編集する** ときの規約に絞る（README と内容を重複させない）。
+
+## プロジェクト概要
+
+willink-claude-kit は、Claude Code / Codex / Antigravity で同等の開発パフォーマンスを得るための
+標準開発エージェント基盤。**Claude Code plugin を正本（canonical）**とし、他環境は adapter skill +
+hash 同期で追従する。提供物の一覧・導入手順は README を参照。
+
+## アーキテクチャ
+
+```
+.claude-plugin/        Claude Code plugin entrypoint（正本）
+  plugin.json          core metadata（name/version/description）
+  marketplace.json     marketplace 定義
+.codex-plugin/
+  plugin.json          Codex entrypoint（plugin.json の core metadata と同期必須）
+codex/sync-manifest.json   Codex 側同期用 hash manifest
+agents/                4 サブエージェント（dev-explorer / dev-planner / dev-tester / dev-reviewer）
+skills/
+  dev-standards/       スタック非依存の汎用標準（正本）
+  codex-build/         /build を Codex に適応する adapter skill
+  antigravity-build/   /build を Antigravity に適応する adapter skill
+commands/build.md      5 phase 版 /build フロー（正本）
+examples/              project-standards 雛形・memory seed・prompt テンプレ
+scripts/check_sync.py  正本 ↔ adapter の hash 同期チェック / 更新
+docs/                  導入ガイド・検証プロトコル・stack 別注意・failure modes
+```
+
+**正本と adapter の関係**: `agents/` `skills/dev-standards/` `commands/build.md` `.claude-plugin/`
+が正本。これらを変更したら Codex / Antigravity 側 adapter と manifest が古くなるため、必ず同期を取る（後述「テスト」）。
+
+## 開発フロー
+
+本 repo の変更も kit 自身の 4 agent / `/build` で回す（dogfooding）。
+
+- **dev-explorer**（read-only）— 変更前のコードベース調査・影響範囲特定
+- **dev-planner**（read-only）— 実装方針の設計。複数ファイルにまたがる変更で起動
+- **dev-tester**（write-allowed）— テスト・検証の実行
+- **dev-reviewer**（read-only）— Generator-Verifier 分離のレビュー段。実装メインとは別 context で telephone game を回避
+
+小規模な単一ファイル変更（docs 1 箇所の修正等）は agent を起動せず直接編集してよい。
+
+- コミットは **Conventional Commits**（`feat:` / `fix:` / `docs:` / `chore:` 等）
+- `agents/` `skills/` `commands/` `.claude-plugin/` を変更したら、同コミット内で manifest を再生成して含める（後述）
+- 配布（tag push / GitHub Release / main への直接配信）は **human-only**。AI agent は実施しない
+
+## テスト
+
+本 repo のテストは「正本と adapter / manifest の同期が崩れていないこと」の検証が中心。
+
+```bash
+python3 scripts/check_sync.py --check    # 同期チェック（CI 相当・exit code で合否）
+python3 scripts/check_sync.py --update   # 正本変更を adapter / manifest に反映
+```
+
+正本ファイルを変更したコミットは `--check` が exit 0 であること（= manifest 反映済み）を満たす。
+
+加えて kit の挙動そのものは、社内プロダクトでの **14 日検証ログ**（追記式の検証記録）と連動して
+品質を担保している。検証指標と記録テンプレは [docs/verification-protocol.md](docs/verification-protocol.md)、
+stack 別の検証到達度（✅ verified / 🟡 install-only）は [docs/known-stack-coverage.md](docs/known-stack-coverage.md) を参照。
+
+## 事業コンテキスト（OSS 配信前提）
+
+本 repo は i-Willink が **OSS として外部配信**するプラグインキット（MIT）。public repo であることを前提に:
+
+- issue / PR / commit / コード本体に **顧客名・契約情報・インフラ ID・社内専用パス**を書かない
+- 社内固有のドメイン知識は本 repo に置かず、各プロジェクトの `.claude/skills/project-standards/` で拡張する（雛形は `examples/project-standards-template/`）
+
+## Q2 2026 検証フェーズ ステータス
+
+- **検証フェーズ**: Day 14/14 **完了**（2026-04-26 → 2026-05-10）。社内 4 プロダクトでの並列検証を実施
+- **到達状況**: 2 / 4 target stacks が ✅ verified（Flutter+Firebase / Next.js+pnpm）、残り 2 stack は 🟡 install-only
+- **現行リリース**: v2.1.0（`.claude-plugin/plugin.json` を正とする。volatile な値は本ファイルに直書きしない）
+- 詳細は [docs/known-stack-coverage.md](docs/known-stack-coverage.md) を参照


### PR DESCRIPTION
Closes #4

## 概要
本プラグイン repo を開発・保守する Claude Code / Codex / Antigravity 向けの開発ガイド `CLAUDE.md` を repo root に新規作成。README（外部導入者向け）とは役割を分離し、CLAUDE.md は本 repo 自体を編集する内部開発者・AI agent 向けの規約に絞った。

## Maker の判断点回答
- **README との重複回避**: README は提供物一覧・導入手順（adopter 向け）を担当。CLAUDE.md は正本↔adapter 同期規約・dev-* 4 agent の使い分け・dogfooding・OSS public 前提の機微情報禁止に絞り、adopter 手順は README へ委譲。
- **検証ログ連動 (Acceptance テスト要件)**: 検証ログ自体は社内管理（public repo に社内パスを書かない denylist 準拠）。CLAUDE.md からは in-repo の公開ドキュメント `docs/verification-protocol.md`（記録テンプレ）と `docs/known-stack-coverage.md`（stack 別到達度）へリンクして連動を表現。
- **Q2 2026 検証フェーズ status**: 専用セクションで Day 14/14 完了（2026-04-26→2026-05-10）・2/4 stack ✅ verified を明記。volatile な version は plugin.json を正とし直書きしない方針も記載。

## Checker 結果（exit code 判定・別 Agent）
| check | 結果 | pass |
|---|---|---|
| `test -f CLAUDE.md` | exit 0 | ✅ |
| 変更範囲 = CLAUDE.md のみ | `git diff --name-only HEAD~1 HEAD` → CLAUDE.md 単独 | ✅ |
| `git diff --check HEAD~1 HEAD` | exit 0（whitespace error なし） | ✅ |
| `python3 scripts/check_sync.py --check` | exit 0 | ✅ |
| 必須セクション 5 種 grep | 全 hit | ✅ |
| dev-explorer/planner/reviewer/tester | 全 hit | ✅ |
| Day N/14 status 言及 | hit（Day 14/14 完了） | ✅ |
| OSS 配信前提 言及 | hit | ✅ |
| CHANGELOG.md 非変更 | diff に不在 | ✅ |
| README 重複 | internal-dev focus・実質重複なし | ✅ |

**VERDICT: PASS**

## 運用メモ
- **auto-merge なし**。人間レビュー後に手動マージしてください（loop-dev-cycle ADR-009 / 配布は human-only）。
- 1 サイクル目（🔁 loop attempt 1/3）で PASS。
