### PR TITLE
feat(test): 回帰/整合テストスイート + CI（テスト常時改善ループの土台）

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,23 @@
+name: test
+
+# Regression / integrity suite (scripts/test/). Runs on every PR and on pushes to main,
+# complementing codex-sync.yml (which only validates adapter sync). The autonomous
+# test-quality loop grows this suite over time; CI is the gate that keeps it green.
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  regression-suite:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.x"
+      - name: Run kit regression / integrity suite
+        run: bash scripts/test/run.sh

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes follow [Keep a Changelog](https://keepachangelog.com/en/1.1.
 
 ## [Unreleased]
 
+### Added
+- 回帰 / 整合テストスイート (`scripts/test/`) + runner (`run.sh`) を新設。kit の不変条件（adapter sync・plugin/marketplace manifest 妥当性・agent guard 句の verbatim 保持・repo 構造・release version pin）をロックする 4 テストファイル（計 43 アサーション）。`.github/workflows/test.yml` で push/PR 時に実行（`codex-sync.yml` は同期特化のまま棲み分け）。テスト常時改善・失敗→ソース改善 issue 化の自走ループ（crew `loop-test-cycle`）の土台。
+
 ## [2.1.0] - 2026-06-13
 
 **Status**: ループ開発サイクル（ADR-009）が自律生成した初のリリース。dev サイクル 4 件（kit #13/#12/#11/#10）を Maker-Checker 分離 + 人間レビューで取り込み、deploy ステージで切り出した。docs 整合の徹底 + check_sync への release 整合性ガード追加が主軸。

--- a/scripts/test/README.md
+++ b/scripts/test/README.md
@@ -1,0 +1,51 @@
+# kit regression / integrity test suite
+
+`willink-claude-kit` is a **prompt / plugin kit**, not application code — there is no
+runtime to unit-test. What *can* regress are the kit's **integrity invariants**: the
+plugin manifests, the adapter sync across Claude / Codex / Antigravity, the agent
+"no early victory" guard phrases, the repo structure, and the release version pins.
+This suite locks those invariants so an edit that silently breaks one is caught.
+
+## Run
+
+```bash
+bash scripts/test/run.sh        # runs every test_*.sh, exits non-zero on any failure
+```
+
+Runs locally (macOS / Linux), in CI (`.github/workflows/test.yml`), and in the
+autonomous test-quality loop.
+
+## Layout
+
+| File | Locks |
+|---|---|
+| `lib.sh` | assertion helpers (`assert_file_exists` / `assert_contains` / `assert_grep` / `assert_match` / `assert_eq` / `assert_cmd_ok` / `t_summary`) |
+| `run.sh` | runner — discovers and runs all `test_*.sh`, aggregates pass/fail |
+| `test_sync.sh` | `check_sync.py --check` (adapter sync + plugin parity + release integrity) |
+| `test_plugin_manifest.sh` | plugin / marketplace / codex manifests are valid JSON with required fields; version is semver |
+| `test_agent_guards.sh` | 4 subagents exist + keep their critical guard phrases verbatim |
+| `test_structure.sh` | required files / dirs (command, adapter skills, agents, docs) exist |
+
+## Add a test (the loop does this continuously)
+
+1. Create `scripts/test/test_<invariant>.sh`.
+2. `source "$(dirname "${BASH_SOURCE[0]}")/lib.sh"` to get `$KIT_ROOT` + assert helpers.
+3. Make assertions, end with `t_summary`.
+4. `bash scripts/test/run.sh` must stay green on `main`.
+
+```bash
+#!/usr/bin/env bash
+source "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+assert_contains "$KIT_ROOT/agents/dev-planner.md" "some invariant phrase" "dev-planner keeps X"
+t_summary
+```
+
+## The autonomous test-quality loop
+
+A scheduled loop (crew `loop-test-cycle` / `CYCLE-PROMPT-test-kit`) continuously:
+1. runs this suite,
+2. **improves coverage** — finds an unlocked invariant and adds one `test_*.sh` (Draft PR, PR-only),
+3. **on failure** — root-causes it: a test bug is fixed; a *source* (prompt/plugin) bug is filed as a `loop:approved` issue for the dev loop to fix.
+
+Regression coverage therefore grows monotonically. Keep tests **fast, deterministic,
+and dependency-free** (bash + python3 + grep only).

--- a/scripts/test/lib.sh
+++ b/scripts/test/lib.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+# scripts/test/lib.sh — minimal, dependency-free assertion library for the kit
+# regression / integrity suite. Each test_*.sh sources this, calls assert_* helpers,
+# then ends with `t_summary` (its exit code becomes the test file's exit code).
+#
+# Portability: pure bash + coreutils + grep -F/-E (no grep -P, no GNU-only flags),
+# so the same tests run on macOS (dev) and ubuntu-latest (CI).
+set -uo pipefail
+
+# Repo root, derived from this file's location (scripts/test/lib.sh -> ../..).
+KIT_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+
+_T_PASS=0
+_T_FAIL=0
+_t_ok()  { _T_PASS=$((_T_PASS + 1)); printf '  \033[32mPASS\033[0m %s\n' "$1"; }
+_t_bad() { _T_FAIL=$((_T_FAIL + 1)); printf '  \033[31mFAIL\033[0m %s\n' "$1"; }
+
+# assert_file_exists <path> [msg]
+assert_file_exists() {
+  if [ -f "$1" ]; then _t_ok "${2:-file exists: $1}"; else _t_bad "${2:-missing file: $1}"; fi
+}
+
+# assert_dir_exists <path> [msg]
+assert_dir_exists() {
+  if [ -d "$1" ]; then _t_ok "${2:-dir exists: $1}"; else _t_bad "${2:-missing dir: $1}"; fi
+}
+
+# assert_contains <file> <fixed-string> [msg] — substring match (grep -F, BSD/GNU safe)
+assert_contains() {
+  if grep -qF -- "$2" "$1" 2>/dev/null; then _t_ok "${3:-'$2' present in $(basename "$1")}"; else _t_bad "${3:-'$2' MISSING in $1}"; fi
+}
+
+# assert_grep <file> <ERE> [msg] — regex match (grep -E)
+assert_grep() {
+  if grep -qE -- "$2" "$1" 2>/dev/null; then _t_ok "${3:-/$2/ in $(basename "$1")}"; else _t_bad "${3:-/$2/ NOT in $1}"; fi
+}
+
+# assert_match <string> <ERE> [msg] — regex match against a literal string
+assert_match() {
+  if printf '%s' "$1" | grep -qE -- "$2" 2>/dev/null; then _t_ok "${3:-/$2/ matches}"; else _t_bad "${3:-/$2/ no match: '$1'}"; fi
+}
+
+# assert_eq <actual> <expected> [msg]
+assert_eq() {
+  if [ "$1" = "$2" ]; then _t_ok "${3:-eq: '$1'}"; else _t_bad "${3:-expected '$2' got '$1'}"; fi
+}
+
+# assert_cmd_ok "<command>" [msg] — eval a command, expect exit 0
+assert_cmd_ok() {
+  if eval "$1" >/dev/null 2>&1; then _t_ok "${2:-ok: $1}"; else _t_bad "${2:-FAILED (exit !=0): $1}"; fi
+}
+
+# t_summary — print per-file tally, return 0 iff every assertion passed.
+t_summary() {
+  printf '  -> %d passed, %d failed\n' "$_T_PASS" "$_T_FAIL"
+  [ "$_T_FAIL" -eq 0 ]
+}

--- a/scripts/test/run.sh
+++ b/scripts/test/run.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+# scripts/test/run.sh — kit regression / integrity test runner.
+#
+# Runs every scripts/test/test_*.sh, prints per-file + suite summary, and exits
+# non-zero if any test file failed. This is the single entry point used by:
+#   - developers locally:  bash scripts/test/run.sh
+#   - CI (.github/workflows/test.yml)
+#   - the autonomous test-quality loop (crew loop-test-cycle / CYCLE-PROMPT-test-kit)
+#
+# The suite locks the kit's *integrity invariants* (this is a prompt/plugin kit, not
+# application code): adapter sync, plugin/marketplace manifests, agent guard phrases,
+# repo structure, release version pins. New invariants are added as test_*.sh files
+# by the test-quality loop over time (regression coverage grows monotonically).
+set -uo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+total=0
+failed=0
+failed_files=""
+
+shopt -s nullglob 2>/dev/null || true
+for t in "$HERE"/test_*.sh; do
+  [ -f "$t" ] || continue
+  total=$((total + 1))
+  name="$(basename "$t")"
+  printf '\n=== %s ===\n' "$name"
+  if bash "$t"; then
+    :
+  else
+    failed=$((failed + 1))
+    failed_files="$failed_files $name"
+  fi
+done
+
+printf '\n========================================\n'
+if [ "$total" -eq 0 ]; then
+  printf 'SUITE: no test_*.sh files found under %s\n' "$HERE"
+  exit 2
+fi
+printf 'SUITE: %d test file(s), %d failed\n' "$total" "$failed"
+if [ "$failed" -ne 0 ]; then
+  printf 'FAILED FILES:%s\n' "$failed_files"
+  exit 1
+fi
+printf 'ALL GREEN\n'

--- a/scripts/test/test_agent_guards.sh
+++ b/scripts/test/test_agent_guards.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+# The 4 subagents exist, carry frontmatter, and KEEP their critical "no early victory"
+# guard phrases. These guards are what make the Generator-Verifier separation work; if
+# a refactor silently drops them, the kit regresses to rubber-stamp reviews. Locked
+# verbatim so any edit to the wording is a deliberate, reviewed change.
+# shellcheck source=scripts/test/lib.sh
+source "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+AG="$KIT_ROOT/agents"
+
+for a in dev-explorer dev-planner dev-reviewer dev-tester; do
+  assert_file_exists "$AG/$a.md"
+  assert_grep "$AG/$a.md" '^name:'        "$a.md has frontmatter name:"
+  assert_grep "$AG/$a.md" '^description:' "$a.md has frontmatter description:"
+done
+
+# Critical guard phrases (verbatim regression locks).
+assert_contains "$AG/dev-tester.md"   'Run the full test suite before marking as passed' \
+  "dev-tester keeps the no-early-victory (full suite) guard"
+assert_contains "$AG/dev-reviewer.md" 'Review the FULL diff before marking PASS' \
+  "dev-reviewer keeps the full-diff guard"
+assert_contains "$AG/dev-explorer.md" 'No nested subagents' \
+  "dev-explorer keeps the no-nested-subagents guard"
+
+t_summary

--- a/scripts/test/test_plugin_manifest.sh
+++ b/scripts/test/test_plugin_manifest.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# The plugin / marketplace / codex manifests are valid JSON and carry the required
+# fields. A broken manifest silently disables the kit in Claude Code, so this is a
+# high-value regression to lock.
+# shellcheck source=scripts/test/lib.sh
+source "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+PLUGIN="$KIT_ROOT/.claude-plugin/plugin.json"
+MARKET="$KIT_ROOT/.claude-plugin/marketplace.json"
+CODEX="$KIT_ROOT/.codex-plugin/plugin.json"
+
+assert_file_exists "$PLUGIN"
+assert_file_exists "$MARKET"
+assert_file_exists "$CODEX"
+
+# valid JSON (python3 is always present in CI + dev)
+assert_cmd_ok "python3 -c 'import json,sys; json.load(open(sys.argv[1]))' '$PLUGIN'"  "plugin.json is valid JSON"
+assert_cmd_ok "python3 -c 'import json,sys; json.load(open(sys.argv[1]))' '$MARKET'"  "marketplace.json is valid JSON"
+assert_cmd_ok "python3 -c 'import json,sys; json.load(open(sys.argv[1]))' '$CODEX'"   "codex plugin.json is valid JSON"
+
+# required non-empty fields on the canonical plugin manifest
+for field in name version description license; do
+  assert_cmd_ok "python3 -c 'import json,sys; d=json.load(open(sys.argv[1])); assert d.get(\"$field\")' '$PLUGIN'" \
+    "plugin.json has non-empty field: $field"
+done
+
+# version is semver, name matches the package
+ver="$(python3 -c 'import json,sys; print(json.load(open(sys.argv[1]))["version"])' "$PLUGIN" 2>/dev/null || true)"
+assert_match "$ver" '^[0-9]+\.[0-9]+\.[0-9]+$' "plugin version is semver (got: '$ver')"
+
+name="$(python3 -c 'import json,sys; print(json.load(open(sys.argv[1]))["name"])' "$PLUGIN" 2>/dev/null || true)"
+assert_eq "$name" "willink-claude-kit" "plugin name == willink-claude-kit"
+
+t_summary

--- a/scripts/test/test_structure.sh
+++ b/scripts/test/test_structure.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+# Required files / directories exist. A missing adapter skill or command file breaks
+# one of the three platforms (Claude / Codex / Antigravity) without any JSON error,
+# so structural presence is its own regression class.
+# shellcheck source=scripts/test/lib.sh
+source "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+# canonical plugin
+assert_file_exists "$KIT_ROOT/.claude-plugin/plugin.json"
+assert_file_exists "$KIT_ROOT/.claude-plugin/marketplace.json"
+assert_file_exists "$KIT_ROOT/.codex-plugin/plugin.json"
+
+# command + adapters
+assert_file_exists "$KIT_ROOT/commands/build.md"
+assert_file_exists "$KIT_ROOT/skills/codex-build/SKILL.md"
+assert_file_exists "$KIT_ROOT/skills/antigravity-build/SKILL.md"
+
+# the 4 subagents
+for a in dev-explorer dev-planner dev-reviewer dev-tester; do
+  assert_file_exists "$KIT_ROOT/agents/$a.md"
+done
+
+# tooling + docs
+assert_file_exists "$KIT_ROOT/scripts/check_sync.py"
+assert_file_exists "$KIT_ROOT/CHANGELOG.md"
+assert_file_exists "$KIT_ROOT/README.md"
+assert_file_exists "$KIT_ROOT/LICENSE"
+
+t_summary

--- a/scripts/test/test_sync.sh
+++ b/scripts/test/test_sync.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+# Regression gate around the canonical sync / parity / release-integrity check.
+# Wraps scripts/check_sync.py --check so adapter drift (Codex/Antigravity hashes,
+# plugin parity, CHANGELOG <-> version-pin integrity) is caught by the suite too.
+# shellcheck source=scripts/test/lib.sh
+source "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+assert_file_exists "$KIT_ROOT/scripts/check_sync.py"
+assert_cmd_ok "python3 '$KIT_ROOT/scripts/check_sync.py' --check" \
+  "check_sync.py --check exits 0 (adapter sync + plugin parity + release integrity)"
+
+t_summary


### PR DESCRIPTION
## 目的

kit は **prompt/plugin kit**（アプリコードなし）のため従来型ユニット/結合テストが存在せず、唯一 `check_sync.py` の整合チェックのみだった。CEO 依頼「テスト常時改善・リグレッション品質向上・失敗時はソース改善 issue 化」の**土台**として、kit の不変条件をロックする回帰スイートを新設する。

## 変更

- `scripts/test/lib.sh` — 依存ゼロの assertion ライブラリ（macOS/Ubuntu portable・grep -F/-E のみ）
- `scripts/test/run.sh` — runner（全 `test_*.sh` を実行・exit code 集約）
- `scripts/test/test_sync.sh` — `check_sync.py --check`（adapter sync/parity/release 整合）を回帰ゲート化（重複せず wrap）
- `scripts/test/test_plugin_manifest.sh` — plugin/marketplace/codex manifest の JSON 妥当性 + 必須フィールド + semver + name
- `scripts/test/test_agent_guards.sh` — 4 subagent の guard 句を **verbatim ロック**（`Run the full test suite...` / `Review the FULL diff...` / `No nested subagents`）+ frontmatter
- `scripts/test/test_structure.sh` — 必須ファイル/ディレクトリ（command・adapter skills・agents・docs）
- `scripts/test/README.md` — スイートの説明・テスト追加手順・自走ループとの関係
- `.github/workflows/test.yml` — push/PR で `run.sh` 実行（`codex-sync.yml` は同期特化のまま棲み分け）
- `CHANGELOG.md` `[Unreleased]` に記録

## 検証

- ローカル `bash scripts/test/run.sh` = **4 ファイル・43 アサーション・0 失敗（ALL GREEN）**
- `python3 scripts/check_sync.py --check` = exit 0（無影響）

## 次段（別 PR）

crew 側に自走ループ（`loop-test-cycle` / `CYCLE-PROMPT-test-kit`）— ①フルスイート実行 ②未カバー不変条件の回帰テスト追加（PR-only）③失敗 root-cause → テストのバグは修正 / **ソース（prompt/plugin）のバグは `loop:approved` issue 起票**。ADR-009 denylist 準拠（tag/release/main 直 push 禁止・self-merge 禁止・gate・secret scan・audit log）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)