### PR TITLE
feat(hooks): hook 雛形 + 自己テストハーネス + 移植性規約ガイド (Closes #22)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,13 @@ permissions:
 
 jobs:
   regression-suite:
-    runs-on: ubuntu-latest
+    # Run on Linux (GNU grep) and macOS (BSD grep) so the example hooks' portability
+    # conventions are proven on both, not just asserted.
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes follow [Keep a Changelog](https://keepachangelog.com/en/1.1.
 ## [Unreleased]
 
 ### Added
+- hook 雛形 + 自己テストハーネス + 規約ガイド (#22) — `examples/hooks/` に fail-closed な PreToolUse 例（危険コマンドを `exit 2` でブロック）と fail-open な Notification 例（エラー時は常に `exit 0`）を追加。両者とも stdin JSON を `jq` で解析し、BSD/GNU 両対応の POSIX ERE（`grep -E`、`grep -P` 不使用）。`examples/hooks/test-hooks.sh` が block/pass 両ケースを自己テスト（フォルダごとコピー可能な自己完結型）。`scripts/test/test_hooks.sh` で既存スイートに統合し、CI を ubuntu + **macos** matrix 化して BSD grep 移植性を実機で実証。規約は `docs/hooks-guide.md`（fail-open/closed・stdin JSON・grep 移植性・有効イベント名一覧）に集約。
 - 回帰 / 整合テストスイート (`scripts/test/`) + runner (`run.sh`) を新設。kit の不変条件（adapter sync・plugin/marketplace manifest 妥当性・agent guard 句の verbatim 保持・repo 構造・release version pin）をロックする 4 テストファイル（計 43 アサーション）。`.github/workflows/test.yml` で push/PR 時に実行（`codex-sync.yml` は同期特化のまま棲み分け）。テスト常時改善・失敗→ソース改善 issue 化の自走ループ（crew `loop-test-cycle`）の土台。
 
 ## [2.1.0] - 2026-06-13

--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@ python3 scripts/check_sync.py --update
 - [docs/verification-protocol.md](docs/verification-protocol.md) — 検証指標と記録テンプレ
 - [docs/stack-specific-notes.md](docs/stack-specific-notes.md) — Next.js / Flutter / WordPress 個別注意
 - [docs/failure-modes.md](docs/failure-modes.md) — Early victory / Telephone game 等の対策
+- [docs/hooks-guide.md](docs/hooks-guide.md) — hook の書き方・自己テスト・fail-open/closed・grep 移植性規約
 
 ## ライセンス
 

--- a/docs/hooks-guide.md
+++ b/docs/hooks-guide.md
@@ -1,0 +1,82 @@
+# Hooks guide — writing and testing Claude Code hooks safely
+
+Hooks are shell commands Claude Code runs at defined lifecycle events. They are powerful
+(a `PreToolUse` hook can block a tool call) and easy to get subtly wrong (silent failures,
+non-portable `grep`, wrong fail policy). This guide consolidates the conventions the kit
+follows; runnable templates live in [`examples/hooks/`](../examples/hooks/).
+
+## 1. Input is JSON on STDIN — parse with `jq`
+
+Hook input arrives as a JSON object on **stdin**, *not* as environment variables. Read it
+and extract fields with `jq`:
+
+```bash
+input="$(cat)"
+tool="$(printf '%s' "$input" | jq -r '.tool_name // empty')"
+cmd="$(printf '%s' "$input" | jq -r '.tool_input.command // empty')"
+```
+
+The payload shape depends on the event (e.g. `PreToolUse` carries `tool_name` /
+`tool_input`; `Notification` carries `message`).
+
+## 2. Fail-closed vs fail-open — pick by the hook's job
+
+A hook *will* eventually hit an internal error (missing `jq`, unparseable input). What it
+does then is a security decision, not an afterthought:
+
+| Hook class | Events | On error | Block signal |
+|---|---|---|---|
+| **Security / gate** | `PreToolUse` | **fail-CLOSED** — `exit 2` (deny) | `exit 2` blocks the call; stderr is shown to Claude |
+| **Advisory / notify** | `PostToolUse`, `Notification`, `Stop`, `SubagentStop`, `UserPromptSubmit`, `SessionStart`, `SessionEnd`, `PreCompact` | **fail-OPEN** — `exit 0` | never disrupt the session |
+
+- Fail-closed means: on an *error* — missing `jq`, unparseable or empty stdin — **deny**
+  (`exit 2`). A security hook that silently allows on error is worse than no hook. (A
+  well-formed payload that simply isn't the call you gate — a non-Bash tool, or no
+  command string — is allowed: there is nothing unsafe to deny.)
+- Fail-open means: a notification hook must never break the session because, say,
+  `notify-send` is missing. Swallow the error and `exit 0`.
+
+`exit 0` = allow / success. `exit 2` = block (PreToolUse) with stderr surfaced to Claude.
+Other non-zero codes are treated as a non-blocking error.
+
+## 3. `grep` portability — macOS ships BSD grep
+
+CI and Linux dev boxes have GNU grep; macOS ships **BSD grep**. Write patterns that run on
+both:
+
+- Use **POSIX ERE** via `grep -E`.
+- **Do not** use `grep -P` (Perl mode) — unsupported on BSD grep.
+- **Do not** use Perl escapes like `\s` `\d` `\w` — use POSIX classes: `[[:space:]]`,
+  `[[:digit:]]`, `[[:alnum:]]`.
+
+```bash
+# portable: matches one-or-more spaces
+grep -qE '[[:space:]]+'        # good
+grep -qP '\s+'                 # BAD — fails on macOS
+```
+
+## 4. Self-test both a block case and a pass case
+
+Every hook ships with a self-test that exercises **both** outcomes — the case it should
+block *and* a case it should let through — plus its fail policy on malformed input. A hook
+that only tests the happy path will silently rot into a rubber stamp. See
+[`examples/hooks/test-hooks.sh`](../examples/hooks/test-hooks.sh); the kit runs it in CI
+via `scripts/test/test_hooks.sh` on both Linux (GNU grep) and macOS (BSD grep).
+
+## 5. Valid event names
+
+Only these events exist. There is **no** `PreCommit` / `PostCommit` / `OnError`:
+
+`PreToolUse` · `PostToolUse` · `UserPromptSubmit` · `Notification` · `Stop` ·
+`SubagentStop` · `PreCompact` · `SessionStart` · `SessionEnd`
+
+## Templates
+
+| File | Class | Policy |
+|---|---|---|
+| [`examples/hooks/pretooluse-block-example.sh`](../examples/hooks/pretooluse-block-example.sh) | `PreToolUse` security gate | fail-closed (`exit 2`) |
+| [`examples/hooks/notification-notify-example.sh`](../examples/hooks/notification-notify-example.sh) | `Notification` advisory | fail-open (`exit 0`) |
+| [`examples/hooks/test-hooks.sh`](../examples/hooks/test-hooks.sh) | self-test harness | block + pass cases |
+
+Wire a hook up in `.claude/settings.json` under `"hooks"` (see each template's header for
+the exact snippet).

--- a/examples/hooks/notification-notify-example.sh
+++ b/examples/hooks/notification-notify-example.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+# Example Notification hook — NOTIFICATION, FAIL-OPEN.
+#
+# Wire it up in .claude/settings.json:
+#   "hooks": {
+#     "Notification": [
+#       { "hooks": [{ "type": "command", "command": ".claude/hooks/notification-notify-example.sh" }] }
+#     ]
+#   }
+#
+# Contract (see docs/hooks-guide.md):
+#   - Input arrives as JSON on STDIN; parse with jq.
+#   - Notification / Stop / SessionEnd / UserPromptSubmit hooks FAIL-OPEN: any
+#     problem exits 0 so the session is NEVER disrupted by the hook.
+#   - Best-effort desktop notification, portable across macOS (osascript) and
+#     Linux (notify-send); neither present → fall back to stdout. None of these
+#     is an error.
+set -uo pipefail
+
+fail_open() { exit 0; }
+
+command -v jq >/dev/null 2>&1 || fail_open
+
+input="$(cat)" || fail_open
+msg="$(printf '%s' "$input" | jq -r '.message // empty')" || fail_open
+[ -n "$msg" ] || fail_open
+
+if command -v osascript >/dev/null 2>&1; then
+  # macOS. The message is passed as data, not interpolated into code paths.
+  osascript -e 'on run {m}' -e 'display notification m with title "Claude Code"' -e 'end run' \
+    -- "$msg" >/dev/null 2>&1 || true
+elif command -v notify-send >/dev/null 2>&1; then
+  notify-send "Claude Code" "$msg" >/dev/null 2>&1 || true
+else
+  printf '[Claude Code] %s\n' "$msg"
+fi
+
+exit 0

--- a/examples/hooks/pretooluse-block-example.sh
+++ b/examples/hooks/pretooluse-block-example.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+# Example PreToolUse hook — SECURITY gate, FAIL-CLOSED.
+#
+# Wire it up in .claude/settings.json:
+#   "hooks": {
+#     "PreToolUse": [
+#       { "matcher": "Bash",
+#         "hooks": [{ "type": "command", "command": ".claude/hooks/pretooluse-block-example.sh" }] }
+#     ]
+#   }
+#
+# Contract (see docs/hooks-guide.md):
+#   - Input arrives as JSON on STDIN (not env vars); parse with jq.
+#   - exit 0 → allow the tool call.  exit 2 → BLOCK it and show stderr to Claude.
+#   - Security (Pre*) hooks FAIL-CLOSED: on any internal error (missing jq,
+#     unparseable input) we BLOCK rather than silently allow.
+#   - Portability: POSIX ERE via `grep -E` only — no Perl-mode matching and no
+#     \s/\d/\w escapes, which BSD grep on macOS does not support.
+set -uo pipefail
+
+fail_closed() {
+  printf 'pretooluse hook error: %s — blocking (fail-closed)\n' "$1" >&2
+  exit 2
+}
+
+command -v jq >/dev/null 2>&1 || fail_closed "jq not found"
+
+# Read stdin. Both reads are guarded so any failure BLOCKS (fail-closed) — a security
+# gate must never continue past a read error and silently allow.
+input="$(cat)" || fail_closed "could not read hook input"
+[ -n "$input" ] || fail_closed "empty hook input"
+tool="$(printf '%s' "$input" | jq -r '.tool_name // empty')" || fail_closed "unparseable hook input"
+cmd="$(printf '%s' "$input" | jq -r '.tool_input.command // empty')" || fail_closed "unparseable tool_input"
+
+# Only gate Bash commands; allow every other tool through. A well-formed payload that
+# simply is not a Bash command has nothing to gate → allow. For real use also assert
+# .tool_input.command is a STRING — a non-string array could carry a command this
+# template's grep would not see.
+[ "$tool" = "Bash" ] || exit 0
+
+# Illustrative denylist — EXTEND for real use; a teaching template, not a complete
+# control. POSIX ERE only (grep -E). Bundled short flags only (-rf / -fr); split
+# (`-r -f`) and long (`--force`) forms are intentionally out of scope. Caught:
+#   1. rm -rf of /, ~, $HOME, or a top-level system dir (/etc, /usr, /var, …)
+#   2. curl/wget … | sh   (pipe remote content straight into a shell)
+#   3. chmod 777 / 0777    (world-writable)
+deny='(^|[[:space:]])rm[[:space:]]+-[[:alpha:]]*f[[:alpha:]]*[[:space:]]+(/|~|\$HOME)([[:space:]]|$)'
+deny="$deny"'|(^|[[:space:]])rm[[:space:]]+-[[:alpha:]]*f[[:alpha:]]*[[:space:]]+/(etc|usr|var|bin|lib|boot|sys|dev|opt|root|sbin)([[:space:]/]|$)'
+deny="$deny"'|(curl|wget)[[:space:]].*\|[[:space:]]*(ba|z)?sh([[:space:]]|$)'
+deny="$deny"'|chmod[[:space:]]+-?[Rr]?[[:space:]]*0?777'
+
+if printf '%s' "$cmd" | grep -qE -- "$deny"; then
+  printf 'blocked dangerous command: %s\n' "$cmd" >&2
+  exit 2
+fi
+
+exit 0

--- a/examples/hooks/test-hooks.sh
+++ b/examples/hooks/test-hooks.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+# Self-test for the example hooks — asserts BOTH a block case and a pass case for each.
+#
+# Self-contained on purpose: no external test library, so you can copy examples/hooks/
+# into your project wholesale and `bash test-hooks.sh` still works. The kit's CI runs
+# this via scripts/test/test_hooks.sh.
+#
+# Requires jq (the hooks parse stdin JSON via jq). If jq is absent it SKIPS (exit 0)
+# rather than failing, to stay friendly in dependency-light environments.
+set -uo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PRE="pretooluse-block-example.sh"
+NOTIF="notification-notify-example.sh"
+
+pass=0; fail=0
+ok()  { pass=$((pass + 1)); printf '  PASS %s\n' "$1"; }
+bad() { fail=$((fail + 1)); printf '  FAIL %s\n' "$1"; }
+
+# run_hook <script> <json-stdin> -> echoes the hook's exit code
+run_hook() {
+  printf '%s' "$2" | bash "$HERE/$1" >/dev/null 2>&1
+  printf '%s' "$?"
+}
+
+if ! command -v jq >/dev/null 2>&1; then
+  printf 'SKIP: jq not installed — hook self-tests need jq. Install jq to run them.\n'
+  exit 0
+fi
+
+# --- PreToolUse (fail-closed) -------------------------------------------------
+# block case: bare root delete -> exit 2
+ec="$(run_hook "$PRE" '{"tool_name":"Bash","tool_input":{"command":"rm -rf /"}}')"
+[ "$ec" = "2" ] && ok "PreToolUse blocks 'rm -rf /' (exit 2)" || bad "PreToolUse should block 'rm -rf /' (got $ec)"
+
+# block case: top-level system dir delete -> exit 2
+ec="$(run_hook "$PRE" '{"tool_name":"Bash","tool_input":{"command":"rm -rf /etc"}}')"
+[ "$ec" = "2" ] && ok "PreToolUse blocks 'rm -rf /etc' (exit 2)" || bad "PreToolUse should block 'rm -rf /etc' (got $ec)"
+
+# pass case: safe command -> exit 0
+ec="$(run_hook "$PRE" '{"tool_name":"Bash","tool_input":{"command":"ls -la"}}')"
+[ "$ec" = "0" ] && ok "PreToolUse allows 'ls -la' (exit 0)" || bad "PreToolUse should allow 'ls -la' (got $ec)"
+
+# pass case: relative-path delete is allowed (denylist gates only root-ish paths —
+# documents the illustrative scope; real use should extend it)
+ec="$(run_hook "$PRE" '{"tool_name":"Bash","tool_input":{"command":"rm -rf node_modules"}}')"
+[ "$ec" = "0" ] && ok "PreToolUse allows 'rm -rf node_modules' (illustrative scope, exit 0)" || bad "PreToolUse should allow relative delete (got $ec)"
+
+# pass case: non-Bash tool is ignored -> exit 0
+ec="$(run_hook "$PRE" '{"tool_name":"Read","tool_input":{"file_path":"/etc/hosts"}}')"
+[ "$ec" = "0" ] && ok "PreToolUse ignores non-Bash tools (exit 0)" || bad "PreToolUse should ignore Read (got $ec)"
+
+# fail-closed: malformed input must BLOCK, never silently allow -> exit 2
+ec="$(run_hook "$PRE" 'not json at all')"
+[ "$ec" = "2" ] && ok "PreToolUse fails closed on malformed input (exit 2)" || bad "PreToolUse should fail closed (got $ec)"
+
+# fail-closed: empty stdin must BLOCK, never silently allow -> exit 2
+ec="$(run_hook "$PRE" '')"
+[ "$ec" = "2" ] && ok "PreToolUse fails closed on empty stdin (exit 2)" || bad "PreToolUse should fail closed on empty stdin (got $ec)"
+
+# --- Notification (fail-open) -------------------------------------------------
+# valid input -> exit 0
+ec="$(run_hook "$NOTIF" '{"message":"build finished"}')"
+[ "$ec" = "0" ] && ok "Notification exits 0 on valid input" || bad "Notification should exit 0 on valid input (got $ec)"
+
+# fail-open: malformed input must NOT disrupt the session -> exit 0
+ec="$(run_hook "$NOTIF" 'not json at all')"
+[ "$ec" = "0" ] && ok "Notification fails open on malformed input (exit 0)" || bad "Notification should fail open (got $ec)"
+
+printf '  -> %d passed, %d failed\n' "$pass" "$fail"
+[ "$fail" -eq 0 ]

--- a/scripts/test/README.md
+++ b/scripts/test/README.md
@@ -25,6 +25,7 @@ autonomous test-quality loop.
 | `test_plugin_manifest.sh` | plugin / marketplace / codex manifests are valid JSON with required fields; version is semver |
 | `test_agent_guards.sh` | 4 subagents exist + keep their critical guard phrases verbatim |
 | `test_structure.sh` | required files / dirs (command, adapter skills, agents, docs) exist |
+| `test_hooks.sh` | example hooks (`examples/hooks/`) exist, are valid bash, and pass their block + pass self-test (behavioral run gated on `jq`) |
 
 ## Add a test (the loop does this continuously)
 

--- a/scripts/test/test_hooks.sh
+++ b/scripts/test/test_hooks.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+# The kit ships example hooks (examples/hooks/) as a copy-paste pattern for writing and
+# self-testing Claude Code hooks safely. Lock that they exist, are valid bash, and that
+# their block+pass self-test passes. Structural checks always run (bash-only); the
+# jq-dependent behavioral run is gated on jq so the core suite stays dependency-light.
+# On macOS CI this run also proves the hooks' BSD-grep portability for real.
+# shellcheck source=scripts/test/lib.sh
+source "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+HOOKS="$KIT_ROOT/examples/hooks"
+
+assert_dir_exists "$HOOKS"
+for h in pretooluse-block-example.sh notification-notify-example.sh test-hooks.sh; do
+  assert_file_exists "$HOOKS/$h"
+  assert_cmd_ok "bash -n '$HOOKS/$h'" "$h is syntactically valid bash"
+done
+
+if command -v jq >/dev/null 2>&1; then
+  assert_cmd_ok "bash '$HOOKS/test-hooks.sh'" \
+    "examples/hooks/test-hooks.sh passes (block + allow + fail-closed cases)"
+else
+  printf '  NOTE jq not installed — ran structural checks only, skipped behavioral self-test\n'
+fi
+
+t_summary


### PR DESCRIPTION
Closes #22

## 概要
harness kit でありながら **hook を安全に書く / テストする再利用パターン**が未提供だった穴を埋める。本番で 10+ hook を自己テスト付きで運用して得た規約を一般化。

## 追加物
| ファイル | 役割 | fail policy |
|---|---|---|
| `examples/hooks/pretooluse-block-example.sh` | PreToolUse security gate | **fail-closed**（`exit 2`） |
| `examples/hooks/notification-notify-example.sh` | Notification advisory | **fail-open**（`exit 0`） |
| `examples/hooks/test-hooks.sh` | 自己完結 self-test（block/allow/fail-closed） | — |
| `scripts/test/test_hooks.sh` | 既存スイート統合（`lib.sh` 再利用・`run.sh` 自動 discover） | — |
| `docs/hooks-guide.md` | 規約集約（fail-open/closed・stdin JSON・grep 移植性・有効イベント名一覧） | — |

- **stdin JSON を `jq` で解析**（env var ではない）/ **BSD・GNU 両対応の POSIX ERE**（`grep -E`、`grep -P` 不使用）
- **`.github/workflows/test.yml` を ubuntu + macos の matrix 化** → BSD grep 移植性を実機 CI で実証（受け入れ条件「macOS/Linux 両対応」を満たす）

## 検証（敵対的レビューで実バグを 1 件検出・修正済み）
correctness / fail-policy / portability の **独立 3 レンズ**で実機検証（sabotage テスト・injection テスト・BSD grep 実行）。`fail-policy` が **再現可能な silent-allow** を検出:
> security hook の `input="$(cat)"` に `|| fail_closed` 欠落 → stdin が directory 等で cat 失敗時に exit 0（許可）に化ける。

→ cat ガード + 空 stdin の fail-closed + denylist を system-root（`/etc` 等）まで拡張 + self-test に該当ケース追加で**修正済み**。
- `examples/hooks/test-hooks.sh` → **9/9 pass**（BSD grep 実機）
- `bash scripts/test/run.sh` → 5 ファイル ALL GREEN

## 受け入れ条件
- [x] Example hooks run on both macOS (BSD grep) and Linux（CI matrix で実証）
- [x] `test-hooks.sh` verifies a block case and a pass case（+ fail-closed / allow）
- [x] conventions documented（fail-open/closed・stdin JSON・grep portability・valid events）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F6XqM5ZF29mNMb6yyLQnna