### PR TITLE
feat(harness): harness profile — 決定論的ゲート導入ガイド + CI summary-job パターン

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes follow [Keep a Changelog](https://keepachangelog.com/en/1.1.
 ## [Unreleased]
 
 ### Added
+- **harness プロファイル** — `docs/harness-profile.md`（決定論的ゲートの H1-H4 ラダー・deterministic-first 5 原則・導入チェックリスト・KPI）+ `examples/ci/all-checks-pass-pattern.md`（CI summary job を唯一の required status check にするパターン。path-filter monorepo での skipped=satisfied 挙動・`if: always()` の必然性・無料枠 branch protection JSON・実運用の落とし穴を含む。willink-labs 3 リポで実証済み）。ホーム org の ADR-019 に基づく。
 - hook 雛形 + 自己テストハーネス + 規約ガイド (#22) — `examples/hooks/` に fail-closed な PreToolUse 例（危険コマンドを `exit 2` でブロック）と fail-open な Notification 例（エラー時は常に `exit 0`）を追加。両者とも stdin JSON を `jq` で解析し、BSD/GNU 両対応の POSIX ERE（`grep -E`、`grep -P` 不使用）。`examples/hooks/test-hooks.sh` が block/pass 両ケースを自己テスト（フォルダごとコピー可能な自己完結型）。`scripts/test/test_hooks.sh` で既存スイートに統合し、CI を ubuntu + **macos** matrix 化して BSD grep 移植性を実機で実証。規約は `docs/hooks-guide.md`（fail-open/closed・stdin JSON・grep 移植性・有効イベント名一覧）に集約。
 - 回帰 / 整合テストスイート (`scripts/test/`) + runner (`run.sh`) を新設。kit の不変条件（adapter sync・plugin/marketplace manifest 妥当性・agent guard 句の verbatim 保持・repo 構造・release version pin）をロックする 4 テストファイル（計 43 アサーション）。`.github/workflows/test.yml` で push/PR 時に実行（`codex-sync.yml` は同期特化のまま棲み分け）。テスト常時改善・失敗→ソース改善 issue 化の自走ループ（crew `loop-test-cycle`）の土台。
 

--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ python3 scripts/check_sync.py --update
 - [docs/stack-specific-notes.md](docs/stack-specific-notes.md) — Next.js / Flutter / WordPress 個別注意
 - [docs/failure-modes.md](docs/failure-modes.md) — Early victory / Telephone game 等の対策
 - [docs/hooks-guide.md](docs/hooks-guide.md) — hook の書き方・自己テスト・fail-open/closed・grep 移植性規約
+- [docs/harness-profile.md](docs/harness-profile.md) — 決定論的ゲートの導入プロファイル（H1-H4 ラダー・CI required check・昇格運用）
 
 ## ライセンス
 

--- a/docs/harness-profile.md
+++ b/docs/harness-profile.md
@@ -1,0 +1,50 @@
+# Harness profile — deterministic gates for AI-driven repos
+
+A minimal, proven set of *deterministic* enforcement layers for repositories where an AI
+coding agent does most of the work. Telling the agent "follow our standards" is
+probabilistic; a gate that exits non-zero is not. This profile packages what the kit's
+home organization enforces in production (ADR-019).
+
+## The ladder
+
+| Layer | What | Where in this kit |
+|---|---|---|
+| H1 | Docs / natural-language rules | `CLAUDE.md`, `examples/project-standards-template/` |
+| H2 | AI semantic review | PR review agents (advisory) |
+| H3 | **Blocking verification** | hooks ([`docs/hooks-guide.md`](hooks-guide.md), [`examples/hooks/`](../examples/hooks/)) + CI required checks ([`examples/ci/`](../examples/ci/)) |
+| H4 | Structural tests | architecture / parity tests (per-stack) |
+
+Rules start at H1 and get **promoted** when violated repeatedly (2+ of the same kind).
+Demoting or loosening a gate is a governance decision — require explicit human approval.
+
+## Principles (deterministic-first)
+
+1. When adding a rule, first ask: *can a linter / test / hook / CI job fail on this?*
+   Natural language is the fallback, not the default.
+2. Gates block by default (`exit != 0`). Warnings are ignored by agents — if it matters,
+   fail.
+3. Set thresholds the agent can comfortably meet even when humans can't (e.g. high branch
+   coverage). Never lower them; never exclude files to pass.
+4. After every incident, add **one** verification that would have caught it.
+5. Documents count too: articles, reports and changelogs can be linted (tone, citations,
+   measured-value markers) like code.
+
+## Adoption checklist
+
+1. **Hooks (local, fail-closed)** — copy [`examples/hooks/`](../examples/hooks/) into
+   `.claude/hooks/`, extend the denylist, wire into `.claude/settings.json`, and keep the
+   self-test green (`bash test-hooks.sh`).
+2. **CI summary gate** — add the
+   [`all-checks-pass` summary job](../examples/ci/all-checks-pass-pattern.md) to your CI
+   and make it the only required status check (free-tier branch protection JSON included).
+3. **Secrets & size guard (pre-commit)** — block committed credentials and oversized
+   files before they reach history; give every check an allowlist escape hatch
+   (`# pragma: allowlist …`) so false positives are one comment away, not a config war.
+4. **Observe, then promote** — log advisory-hook fires (JSONL) and review monthly:
+   2+ true positives of one kind → promote to blocking; mostly false positives → tune.
+
+## KPIs worth tracking monthly
+
+- Natural-language-only rules remaining (should trend down)
+- Required status checks across repos (should trend up)
+- Advisory → blocking promotions (with dates)

--- a/examples/ci/all-checks-pass-pattern.md
+++ b/examples/ci/all-checks-pass-pattern.md
@@ -1,0 +1,79 @@
+# The "All checks passed" summary-job pattern
+
+A single summary job that aggregates every CI job, meant to be the **only** required
+status check in branch protection. Battle-tested across Flutter, Next.js and monorepo
+CIs (willink-labs tsuu / fit-ai / clublink-platform, 2026-07).
+
+## Why one summary job instead of requiring each job
+
+- **Robust to renames** — add/rename/split CI jobs freely; branch protection keeps
+  pointing at one stable context (`All checks passed`).
+- **Path-filtered monorepos work** — GitHub treats a *skipped* check as satisfied, so
+  jobs skipped via `dorny/paths-filter` (untouched areas) don't block the PR, while a
+  *failed* job does.
+- **No silent green** — the summary job inspects each `needs` result explicitly and
+  exits 1 on `failure`/`cancelled`; `if: always()` guarantees it reports even when
+  upstream jobs fail (otherwise it would be *skipped* — which counts as satisfied!).
+
+## Template (append to your workflow's `jobs:`)
+
+```yaml
+  all-checks-pass:
+    name: All checks passed
+    runs-on: ubuntu-latest
+    needs: [lint, test, build]        # ← list EVERY job in this workflow
+    if: always()                      # ← REQUIRED: must run even when a need fails
+    steps:
+      - name: Verify no needed job failed
+        run: |
+          results='${{ join(needs.*.result, ',') }}'
+          echo "needs results: $results"
+          case ",$results," in
+            *,failure,*|*,cancelled,*)
+              echo "One or more checks failed"
+              exit 1
+              ;;
+          esac
+          echo "All checks passed"
+```
+
+For a small non-path-filtered CI you can be stricter — require `success` explicitly
+(skipped also fails):
+
+```yaml
+      - name: Verify all jobs succeeded
+        run: |
+          if [ "${{ needs.lint.result }}" != "success" ] || \
+             [ "${{ needs.build.result }}" != "success" ]; then
+            echo "One or more checks failed"; exit 1
+          fi
+          echo "All checks passed"
+```
+
+## Branch protection (free tier; no paid add-ons)
+
+```bash
+gh api -X PUT "repos/OWNER/REPO/branches/main/protection" --input - <<'EOF'
+{
+  "required_status_checks": { "strict": false, "contexts": ["All checks passed"] },
+  "enforce_admins": false,
+  "required_pull_request_reviews": {
+    "dismiss_stale_reviews": true,
+    "require_code_owner_reviews": false,
+    "required_approving_review_count": 0
+  },
+  "restrictions": null,
+  "allow_force_pushes": false,
+  "allow_deletions": false
+}
+EOF
+```
+
+Pitfalls learned in production:
+
+- Existing open PRs need a branch update / CI re-run before the new required context is
+  reported — Dependabot PRs pick it up on rebase.
+- Verify your `lint` script actually works before gating on it. (A repo we gated had
+  `next lint` silently broken for months — the very first CI run caught it.)
+- Loosening or removing a required check is a governance decision, not a convenience —
+  treat it like removing a lock.


### PR DESCRIPTION
crew #762（ADR-019 B5）第 1 弾。#28（hook 雛形）の上に harness プロファイルを構築。

- **docs/harness-profile.md**: H1-H4 ラダー・deterministic-first 5 原則・導入チェックリスト（hooks → CI summary gate → secrets guard → observe&promote）・KPI
- **examples/ci/all-checks-pass-pattern.md**: 「All checks passed」summary job を唯一の required status check にするパターン。willink-labs 3 リポ（tsuu/fit-ai/clublink）の本番導入で実証済み。skipped=satisfied 挙動・`if: always()` の必然性・無料枠 branch protection JSON・実運用の落とし穴（lint が最初から壊れていた事例）込み

ドキュメントのみ・コード変更なし。後続: 本番級 hook 群の移植・stack 別 CI 雛形 yml・1 リポ追従実証。