### PR TITLE
fix(docs): 導入手順の array pin 例が kit を silently 無効化する問題を修正 + 再発防止ハーネス

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,12 +5,17 @@ All notable changes follow [Keep a Changelog](https://keepachangelog.com/en/1.1.
 ## [Unreleased]
 
 ### Added
+- **導入 doctor `scripts/check-kit-enabled.sh`** — 「インストール済み」と「実際にロードされているか」を区別して検査する自己診断。`enabledPlugins` の値型（boolean / array / string / false / 未宣言）・`installed_plugins.json` の登録と installPath 実在・plugin.json の JSON 妥当性・commands/agents/skills の件数を検査し、問題ごとに具体的な fix を出して exit 1。`/plugin` の「有効」表示は silently-disabled 状態を検出できないため、導入直後と kit 更新後はこれを正とする。`CLAUDE_CONFIG_DIR` を尊重し user / project / project-local の 3 scope を走査。python3 stdlib のみ。
+- `scripts/test/test_install_docs.sh` — 導入ドキュメントが「kit を silently 無効化するスニペット」を再び配ることを CI で禁止する回帰ロック。README / adoption-guide には array 代入例と「必ず pin」の誤指示が現れないこと、警告と doctor への導線があること、failure-modes には逆に **NG ラベル付きで**同じ array 例が残ること（アンチパターンの教材を消さない）を検証。3 パターンの変異テストで rubber-stamp でないことを確認済み。
+- `scripts/test/lib.sh` に `assert_not_contains` を追加（アンチパターンの不在をロックする用途）。
 - `/build` 失敗モードガードの verbatim ロックテスト (`scripts/test/test_build_guards.sh`) — `commands/build.md` が early-victory / telephone-game / options-flooding / Generator-Verifier の各不変条件を保持しているか検証（agent 側の `test_agent_guards.sh` と対で、`/build` フロー自体の silent な弱体化も捕捉）。併せて `test_structure.sh` の構造保証を canonical plugin + downstream scaffold まで拡張。
 
 ### Changed
 - docs ステータス整合 — README の Status を陳腐化した「v1.0 — partial Go」から現行の stable-surface 表記へ更新し、pre-1.0 のロードマップ（v0.1.x〜v1.0.0）を 2.x 到達後の実態（3 環境基盤完了 / Q3 stack promotion / 継続評価）へ差し替え。`model: inherit` 運用と矛盾する README の「Opus 4.7 前提」ハードコードを除去。`CLAUDE.md` の検証フェーズ節を完了済み 14 日検証 + 現フェーズ（Q3 promotion）表記に更新。`docs/known-stack-coverage.md` の as-of スナップショットが現行版でも有効である旨を明記
 
 ### Fixed
+- **導入手順が kit を silently 無効化していた問題** — README / adoption-guide がバージョン pin 例として `"willink-claude-kit@iwillink": ["2.2.0"]`（array 単独）への置き換えを案内し、adoption-guide は「Phase B 検証中は **必ず pin** する」と誘導していた。この指示に従うと `/plugin` 上は「有効」と表示されたまま、コマンド（`/build` `/pulse` `/goal-loop`）・4 サブエージェント・全スキルが一切ロードされない状態になる（**エラーも警告も出ない**）。実環境で約 6 日間検知されなかった。有効化の値は boolean `true` に統一し（Claude Code 自身が有効化時に書き込む形式）、バージョン固定は marketplace の `source.ref`（tag）で行う方針へ変更。`docs/failure-modes.md` に #11 として症状・原因・復旧手順を追加し、#9 の「`enabledPlugins` で pin 推奨」という誤った対策記述も修正。
+  > なお値型による有効化差異そのものは Claude Code 公式ドキュメント（settings reference / plugins reference / JSON schema, 2026-07 時点）には記載が無く、上記は実環境での観測に基づく。公式に確認できるのは「有効化時に Claude Code が `true` を書き込む」ことのみ。
 - `docs/antigravity-adoption-guide.md` の SKILL.md リンクを machine-specific な絶対パス `file:///Users/...` から相対パスへ修正（OSS 配信で解決可能に）
 
 ## [2.2.0] - 2026-07-11

--- a/README.md
+++ b/README.md
@@ -50,9 +50,15 @@ Claude Code / Codex / Antigravity 向け標準開発エージェント基盤。C
 }
 ```
 
-バージョン pin 例: `"willink-claude-kit@iwillink": ["2.2.0"]`
+> ⚠️ **値は boolean の `true` で書くこと。** Claude Code がプラグインを有効化するとき自身が書き込むのもこの形式。
+> `["2.2.0"]` のような **array 単独の値に置き換えてはいけない** — `/plugin` 上は「有効」と表示されたまま、
+> コマンド・サブエージェント・スキルが一切ロードされない状態になる事例が確認されている
+> （[failure-modes #11](docs/failure-modes.md) 参照）。
+>
+> バージョンは marketplace 側の tag ref（`.claude-plugin/marketplace.json` の `ref`）で固定されるため、
+> `enabledPlugins` 側での pin は不要。
 
-> Claude Code 公式 `settings.json` schema は `enabledPlugins.<plugin>` の値として `boolean` または `array<string>` のみ受け付ける。バージョン pin は **array 形式**で書くこと（string `"0.1.1"` は schema validator に弾かれる）。
+導入後は `bash scripts/check-kit-enabled.sh` で「インストール済み」ではなく **実際にロードされているか** を確認できる。
 
 詳細は [docs/adoption-guide.md](docs/adoption-guide.md) を参照。
 

--- a/docs/adoption-guide.md
+++ b/docs/adoption-guide.md
@@ -19,11 +19,36 @@
 }
 ```
 
-バージョン pin する場合: `"willink-claude-kit@iwillink": ["2.2.0"]`
+> ⚠️ **値は boolean の `true` で書くこと。** Claude Code がプラグインを有効化するとき自身が書き込むのもこの形式。
+>
+> `["2.2.0"]` のような **array 単独の値に置き換えてはいけない**。`/plugin` 上は「有効」と表示されたまま、
+> コマンド（`/build` `/pulse` `/goal-loop`）・4 サブエージェント・全スキルが一切ロードされない状態になる事例が
+> 確認されている。**エラーも警告も出ない**ため、気付かないまま kit 無しで作業し続けることになる。
+> 詳細と復旧手順は [failure-modes.md #11](failure-modes.md) を参照。
+>
+> なお `"2.2.0"` のような **string 直書きは schema 違反**で validator に弾かれる（`$schema` を宣言したリポでは特に）。
 
-> Phase B 検証中は **必ず pin** する（v0.x は破壊的変更ありうるため）
+### バージョンを固定したい場合
 
-> ⚠️ Claude Code 公式 `settings.json` schema は `enabledPlugins.<plugin>` の値として `boolean` または `array<string>` のみ受け付ける。`"0.1.1"` のような **string は schema 違反**で validator に弾かれる（`$schema` を宣言したリポでは特に）。array 形式 `["0.1.1"]` を使うこと。
+`enabledPlugins` では pin しない。バージョンは **marketplace 側の tag ref** で固定する
+（`.claude-plugin/marketplace.json` の `source.ref`、例: `willink-claude-kit--v2.2.0`）。
+`enabledPlugins` の値は常に `true` のままでよい。
+
+### 導入できたかの確認
+
+「インストール済み」と「実際にロードされている」は別物なので、導入直後に必ず確認する:
+
+```bash
+# kit repo を clone している場合
+bash scripts/check-kit-enabled.sh
+
+# marketplace 経由で導入した場合（インストール実体から実行）
+bash ~/.claude/plugins/cache/iwillink/willink-claude-kit/*/scripts/check-kit-enabled.sh
+```
+
+`enabledPlugins` の値型・インストール実体・commands/agents/skills の有無を検査し、
+問題があれば exit 1 と具体的な fix を返す。`/plugin` の表示だけでは上記の
+silently-disabled 状態を検出できないため、これを正とする。
 
 ## 2. project-standards を作成
 

--- a/docs/failure-modes.md
+++ b/docs/failure-modes.md
@@ -112,7 +112,8 @@
 **症状**: kit を v0.2 に上げたら下流リポで挙動が変わって混乱
 
 **kit の対策**:
-- 各リポで `@version` pin 推奨（adoption-guide.md）
+- バージョン固定は **marketplace 側の tag ref**（`marketplace.json` の `source.ref`）で行う。
+  `enabledPlugins` の値で pin してはいけない（→ #11）
 - CHANGELOG に破壊的変更を必ず明記
 - v1.0.0 までは破壊的変更ありうる旨を README に明示
 
@@ -125,3 +126,37 @@
 **kit の対策**:
 - 200 行上限を agent prompt に明記（公式の自動 curate 機構と同じ閾値）
 - 月次で MEMORY.md を確認・古い pattern を削除（kit 月次レビュー手順に追加予定）
+
+---
+
+## 11. kit が silently 無効化される（enabledPlugins の値型）
+
+**症状**: `/plugin` ではプラグインが「有効」と表示されるのに、`/build` `/pulse` `/goal-loop` が
+`Unknown command` になり、4 サブエージェントも全スキルもロードされない。**エラーも警告も一切出ない**ため、
+kit が効いていないことに気付かないまま作業が続く（実例: 約 6 日間気付かず）。
+
+**原因**: `settings.json` の `enabledPlugins` の値を boolean `true` から
+array 単独（`["2.2.0"]`）に書き換えた。有効化のトリガーは boolean であり、
+Claude Code 自身がプラグイン有効化時に書き込むのも `true`。
+
+```jsonc
+// NG — /plugin 上は「有効」だが何もロードされない
+"enabledPlugins": { "willink-claude-kit@iwillink": ["2.2.0"] }
+
+// OK
+"enabledPlugins": { "willink-claude-kit@iwillink": true }
+```
+
+> この値型による有効化差異は **Claude Code の公式ドキュメントには記載が無い**（2026-07 時点で
+> settings reference / plugins reference / JSON schema を確認済み）。上記は実環境での観測に基づく。
+> 公式に確認できるのは「有効化時に Claude Code が `true` を書き込む」ことのみ。
+
+**kit の対策**:
+- README / adoption-guide から array 形式の pin 例を削除し、`true` 固定に修正
+- バージョン固定は marketplace の tag ref で行う方針に統一（→ #9）
+- `scripts/check-kit-enabled.sh` … 値型・インストール実体・コマンド/エージェント/スキルの
+  存在を検査する doctor。「インストール済み」と「ロード済み」を区別して報告する
+- `scripts/test/test_install_docs.sh` … docs に危険な array 代入例が再混入したら CI で落とす
+
+**運用側の対策**: 導入直後と kit 更新後に `bash scripts/check-kit-enabled.sh` を実行する。
+`/plugin` の表示は根拠にしない（有効表示のまま未ロードになりうる）。

--- a/scripts/check-kit-enabled.sh
+++ b/scripts/check-kit-enabled.sh
@@ -1,0 +1,162 @@
+#!/usr/bin/env bash
+# scripts/check-kit-enabled.sh — "is the kit actually LOADED?" doctor.
+#
+# Why this exists: the kit can be fully installed on disk and shown as enabled in
+# /plugin while loading nothing at all. The known trigger is an `enabledPlugins`
+# value written as an array (`["2.2.0"]`) instead of the boolean `true` — Claude Code
+# writes `true` when it enables a plugin, and the array-only form has been observed
+# to leave the plugin listed-but-dead. It fails silently: no error, no warning, and
+# /plugin still says "enabled", so nobody notices the kit stopped working.
+# See docs/failure-modes.md #11.
+#
+# This script separates two things the UI conflates:
+#   INSTALLED = files are on disk        LOADED = Claude Code will actually register them
+#
+# Exit: 0 = healthy, 1 = problem found (actionable diagnosis printed).
+# Portability: bash + python3 only (macOS dev + ubuntu CI).
+set -uo pipefail
+
+PLUGIN_ID="willink-claude-kit@iwillink"
+CLAUDE_HOME="${CLAUDE_CONFIG_DIR:-$HOME/.claude}"
+PROBLEMS=0
+
+c_ok()   { printf '  \033[32mOK\033[0m   %s\n' "$1"; }
+c_bad()  { printf '  \033[31mNG\033[0m   %s\n' "$1"; PROBLEMS=$((PROBLEMS + 1)); }
+c_warn() { printf '  \033[33m??\033[0m   %s\n' "$1"; }
+
+# json_get <file> <python-expr over `d`> — print result, empty on any failure.
+json_get() {
+  python3 -c '
+import json,sys
+try:
+    d = json.load(open(sys.argv[1]))
+except Exception:
+    sys.exit(1)
+try:
+    # `json` must be in scope: callers pass expressions like json.dumps(...).
+    v = eval(sys.argv[2], {"json": json}, {"d": d})
+except Exception:
+    sys.exit(1)
+print("" if v is None else v)
+' "$1" "$2" 2>/dev/null
+}
+
+printf '\n=== willink-claude-kit doctor ===\n'
+printf 'plugin: %s\n' "$PLUGIN_ID"
+
+# ---------------------------------------------------------------------------
+# 1. enabledPlugins の値型 — 今回の silent-disable の本丸
+# ---------------------------------------------------------------------------
+printf '\n[1] enabledPlugins の値型\n'
+
+FOUND_SCOPE=""
+for scope_file in \
+  "$CLAUDE_HOME/settings.json" \
+  "$PWD/.claude/settings.json" \
+  "$PWD/.claude/settings.local.json"
+do
+  [ -f "$scope_file" ] || continue
+
+  raw="$(json_get "$scope_file" "json.dumps(d.get('enabledPlugins',{}).get('$PLUGIN_ID','__ABSENT__'))")"
+  [ -n "$raw" ] || continue
+  [ "$raw" = '"__ABSENT__"' ] && continue
+
+  FOUND_SCOPE="$scope_file"
+  kind="$(json_get "$scope_file" "type(d.get('enabledPlugins',{}).get('$PLUGIN_ID')).__name__")"
+
+  case "$raw" in
+    true)
+      c_ok "$scope_file → true (boolean) — 正しい有効化形式"
+      ;;
+    false)
+      c_bad "$scope_file → false — 明示的に無効化されている"
+      printf '       fix: \"%s\": true に変更\n' "$PLUGIN_ID"
+      ;;
+    \[*)
+      c_bad "$scope_file → $raw (array) — /plugin 上は「有効」でも一切ロードされない"
+      printf '       fix: \"%s\": true に変更（array 単独では有効化されない）\n' "$PLUGIN_ID"
+      printf '       バージョン固定は marketplace の source.ref で行う。docs/failure-modes.md #11\n'
+      ;;
+    *)
+      c_bad "$scope_file → $raw ($kind) — boolean ではない不正な値型"
+      printf '       fix: \"%s\": true に変更\n' "$PLUGIN_ID"
+      ;;
+  esac
+done
+
+if [ -z "$FOUND_SCOPE" ]; then
+  c_bad "どの settings.json にも $PLUGIN_ID の宣言が無い（未有効化）"
+  printf '       fix: .claude/settings.json の enabledPlugins に \"%s\": true を追加\n' "$PLUGIN_ID"
+fi
+
+# ---------------------------------------------------------------------------
+# 2. インストール実体
+# ---------------------------------------------------------------------------
+printf '\n[2] インストール実体\n'
+
+INSTALLED_JSON="$CLAUDE_HOME/plugins/installed_plugins.json"
+INSTALL_PATH=""
+if [ -f "$INSTALLED_JSON" ]; then
+  INSTALL_PATH="$(json_get "$INSTALLED_JSON" "(d.get('plugins',{}).get('$PLUGIN_ID') or [{}])[0].get('installPath','')")"
+  VER="$(json_get "$INSTALLED_JSON" "(d.get('plugins',{}).get('$PLUGIN_ID') or [{}])[0].get('version','')")"
+  if [ -n "$INSTALL_PATH" ]; then
+    c_ok "installed_plugins.json に登録あり (version=${VER:-unknown})"
+  else
+    c_bad "installed_plugins.json に $PLUGIN_ID が無い（未インストール）"
+    printf '       fix: /plugin から marketplace 経由でインストール\n'
+  fi
+else
+  c_warn "installed_plugins.json が無い: $INSTALLED_JSON"
+fi
+
+if [ -n "$INSTALL_PATH" ]; then
+  if [ -d "$INSTALL_PATH" ]; then
+    c_ok "installPath 実在: $INSTALL_PATH"
+  else
+    c_bad "installPath が存在しない: $INSTALL_PATH"
+    printf '       fix: /plugin で一度 uninstall → 再 install\n'
+  fi
+fi
+
+# ---------------------------------------------------------------------------
+# 3. ロード対象の中身（コマンド / エージェント / スキル）
+# ---------------------------------------------------------------------------
+printf '\n[3] ロード対象の中身\n'
+
+if [ -n "$INSTALL_PATH" ] && [ -d "$INSTALL_PATH" ]; then
+  if [ -f "$INSTALL_PATH/.claude-plugin/plugin.json" ]; then
+    if python3 -c 'import json,sys; json.load(open(sys.argv[1]))' \
+        "$INSTALL_PATH/.claude-plugin/plugin.json" 2>/dev/null; then
+      c_ok "plugin.json は valid JSON"
+    else
+      c_bad "plugin.json が壊れている（parse 不能）— プラグイン全体がロードされない"
+    fi
+  else
+    c_bad "plugin.json が無い: $INSTALL_PATH/.claude-plugin/plugin.json"
+  fi
+
+  for d in commands agents skills; do
+    if [ -d "$INSTALL_PATH/$d" ]; then
+      n="$(find "$INSTALL_PATH/$d" -maxdepth 1 -mindepth 1 | wc -l | tr -d ' ')"
+      c_ok "$d/ … $n 件"
+    else
+      c_bad "$d/ が無い"
+    fi
+  done
+else
+  c_warn "installPath 未確定のため中身検査をスキップ"
+fi
+
+# ---------------------------------------------------------------------------
+# 判定
+# ---------------------------------------------------------------------------
+printf '\n========================================\n'
+if [ "$PROBLEMS" -eq 0 ]; then
+  printf '\033[32mHEALTHY\033[0m — 設定・実体ともに正常。\n'
+  printf 'セッションに未反映の場合は Claude Code を再起動して /build が通るか確認する。\n'
+  exit 0
+fi
+
+printf '\033[31m%d 件の問題を検出\033[0m — 上記 fix を適用後、Claude Code を再起動して反映する。\n' "$PROBLEMS"
+printf '再起動しないと settings.json を直しても現セッションには反映されない。\n'
+exit 1

--- a/scripts/test/lib.sh
+++ b/scripts/test/lib.sh
@@ -30,6 +30,13 @@ assert_contains() {
   if grep -qF -- "$2" "$1" 2>/dev/null; then _t_ok "${3:-'$2' present in $(basename "$1")}"; else _t_bad "${3:-'$2' MISSING in $1}"; fi
 }
 
+# assert_not_contains <file> <fixed-string> [msg] — assert a substring is ABSENT.
+# For locking out anti-patterns that must never reappear (e.g. a copy-pasteable docs
+# snippet that silently disables the kit).
+assert_not_contains() {
+  if grep -qF -- "$2" "$1" 2>/dev/null; then _t_bad "${3:-'$2' MUST NOT appear in $1}"; else _t_ok "${3:-'$2' absent from $(basename "$1")}"; fi
+}
+
 # assert_grep <file> <ERE> [msg] — regex match (grep -E)
 assert_grep() {
   if grep -qE -- "$2" "$1" 2>/dev/null; then _t_ok "${3:-/$2/ in $(basename "$1")}"; else _t_bad "${3:-/$2/ NOT in $1}"; fi

--- a/scripts/test/test_install_docs.sh
+++ b/scripts/test/test_install_docs.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+# The install docs must never hand users a snippet that silently disables the kit.
+#
+# Regression being locked (docs/failure-modes.md #11): README.md and adoption-guide.md
+# used to present `"willink-claude-kit@iwillink": ["2.2.0"]` as a drop-in "version pin"
+# for the boolean `true`. Following that advice leaves the plugin shown as enabled in
+# /plugin while loading NO commands, agents or skills — with no error output at all.
+# One environment ran ~6 days that way before anyone noticed.
+#
+# These are docs assertions rather than code assertions on purpose: for a prompt/plugin
+# kit the install snippet IS the interface, and a wrong snippet breaks every adopter.
+# shellcheck source=scripts/test/lib.sh
+source "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+README="$KIT_ROOT/README.md"
+GUIDE="$KIT_ROOT/docs/adoption-guide.md"
+MODES="$KIT_ROOT/docs/failure-modes.md"
+DOCTOR="$KIT_ROOT/scripts/check-kit-enabled.sh"
+
+assert_file_exists "$README"
+assert_file_exists "$GUIDE"
+assert_file_exists "$MODES"
+
+# --- 1. the enable form is the boolean, in every install snippet -------------
+for f in "$README" "$GUIDE"; do
+  assert_contains "$f" '"willink-claude-kit@iwillink": true' \
+    "$(basename "$f"): 有効化例が boolean true"
+done
+
+# --- 2. the dangerous array assignment must never reappear -------------------
+# Scoped to the install docs: those are the copy-paste surface, where the snippet is
+# read as an instruction. failure-modes.md is deliberately excluded — see check 5,
+# which requires the same string there *labelled NG* so the anti-pattern stays taught.
+for f in "$README" "$GUIDE"; do
+  assert_not_contains "$f" '"willink-claude-kit@iwillink": ["' \
+    "$(basename "$f"): array 代入例が存在しない"
+done
+
+# --- 3. the anti-pattern is explicitly warned about --------------------------
+for f in "$README" "$GUIDE"; do
+  assert_contains "$f" 'array 単独' \
+    "$(basename "$f"): array 単独形式への警告がある"
+done
+
+# --- 4. the actively harmful instruction stays deleted -----------------------
+# "必ず pin する" told users to replace the working boolean with the broken array.
+assert_not_contains "$GUIDE" '必ず pin' \
+  "adoption-guide: 「必ず pin」の誤指示が復活していない"
+
+# --- 5. the failure mode stays documented ------------------------------------
+assert_contains "$MODES" '## 11. kit が silently 無効化される' \
+  "failure-modes: #11 が存在する"
+assert_contains "$MODES" 'source.ref' \
+  "failure-modes: pin は marketplace ref で行う方針が記載されている"
+# The anti-pattern must stay *shown* here (labelled NG), so readers can recognise it
+# in their own settings.json — the inverse of check 2's rule for the install docs.
+assert_contains "$MODES" '"willink-claude-kit@iwillink": ["' \
+  "failure-modes: array 形式の NG 例が掲載されている"
+assert_contains "$MODES" '// NG' \
+  "failure-modes: NG ラベルが付いている"
+
+# --- 6. the doctor referenced by the docs actually exists and parses ---------
+assert_file_exists "$DOCTOR"
+assert_cmd_ok "bash -n '$DOCTOR'" "check-kit-enabled.sh は bash 構文として妥当"
+for f in "$README" "$GUIDE"; do
+  assert_contains "$f" 'scripts/check-kit-enabled.sh' \
+    "$(basename "$f"): doctor スクリプトへの導線がある"
+done
+
+t_summary


### PR DESCRIPTION
## 背景 — 実際に起きたこと

導入済み環境で `/build` `/pulse` `/goal-loop` がすべて `Unknown command` になり、4 サブエージェントも全スキルもロードされない状態が発生。`/plugin` 画面では **「有効」と表示されたまま**、エラーも警告も一切出ないため気付けず、**約 6 日間検知されなかった**。

原因は本 repo の導入ドキュメントだった。

## 原因

README / adoption-guide が、バージョン pin の方法として boolean からの置き換えを案内していた:

```jsonc
// docs が案内していた形（これに従うと死ぬ）
"enabledPlugins": { "willink-claude-kit@iwillink": ["2.2.0"] }
```

adoption-guide に至っては **「Phase B 検証中は必ず pin する」** と誘導しており、指示に従った環境ほど確実に壊れる状態だった。有効化のトリガーは boolean であり、Claude Code 自身が有効化時に書き込むのも `true`。

実環境の裏付け（settings.json のバックアップ）:

| 時点 | 値 | 状態 |
|---|---|---|
| kit インストール前 | `true` | 動作していた |
| インストール作業後 | `["2.2.0"]` | 全機能が無効（表示は「有効」） |

## 確認できたこと / できなかったこと

**公式ドキュメントに記載が無い。** settings reference / plugins reference / JSON schema を確認したが、値型による有効化差異は文書化されていない（2026-07 時点）。公式に確認できるのは「Claude Code は有効化時に `true` を書き込む」ことのみ。

そのため本 PR は **メカニズムの断定を避け**、「`true` が正規形」「array 単独は未ロード事例が確認されている」という検証済みの範囲で記述している。仕様の解釈によらず `true` を推奨する結論は安全側に倒れる。

## 変更内容

### ドキュメント修正
- `README.md` / `docs/adoption-guide.md` — array pin 例を削除し `true` に統一。「必ず pin」の誤指示を削除。バージョン固定は marketplace の `source.ref`（tag）で行う方針を明記
- `docs/failure-modes.md` — **#11「kit が silently 無効化される」**を追加（症状・原因・復旧手順・公式未文書である旨）。誤った対策を書いていた **#9 も修正**

### 再発防止ハーネス
- **`scripts/check-kit-enabled.sh`**（新規）— 「インストール済み」と「実際にロード可能か」を分離して検査する doctor。`/plugin` の表示を根拠にしないための実測ツール
- **`scripts/test/test_install_docs.sh`**（新規）— 危険なスニペットの docs 再混入を CI で禁止
- `scripts/test/lib.sh` — `assert_not_contains` を追加

## 検証

**doctor は事故を再現して検出できる**（fixture で 5 パターン）:

| ケース | 判定 | exit |
|---|---|---|
| `["2.2.0"]`（今回の事故） | NG + fix 提示 | 1 |
| `"2.2.0"`（string / schema 違反） | NG | 1 |
| `false` | NG | 1 |
| 宣言なし | NG | 1 |
| `true` | OK | 0 |

事故ケースでは **[2] インストール実体・[3] 中身は全て緑のまま [1] だけが落ちる** — まさに「インストールは完璧なのに動かない」という本件の署名を捉えている。

**回帰テストは rubber-stamp でない**（変異テスト 3 件、いずれも検出）:
- README に array 代入例を再導入 → FAIL
- adoption-guide に「必ず pin」を再導入 → FAIL
- doctor スクリプトを削除 → FAIL

**スイート全体**: 19 test file **ALL GREEN** / `check_sync.py --check` exit 0

## レビュー観点

- 公式未文書な挙動の記述として、断定の強さが適切か（`failure-modes.md` #11 の注記）
- `failure-modes.md` にのみ NG 例の array を残す設計（教材として残しつつ、コピペ面の README/guide からは排除）が妥当か

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KSY7U76g6qP9HPLDYTe3dE