### PR TITLE
chore(release): v2.3.0 — 導入手順の silent-disable 修正 + 再発防止ハーネス

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,10 +10,10 @@
       "source": {
         "source": "url",
         "url": "https://github.com/willink-oss/willink-claude-kit.git",
-        "ref": "willink-claude-kit--v2.2.0"
+        "ref": "willink-claude-kit--v2.3.0"
       },
       "description": "標準サブエージェント 4 本 + 5 phase /build フローを束ねた開発キット。Generator-Verifier 分離・並列探索・project-standards 拡張に対応。",
-      "version": "2.2.0",
+      "version": "2.3.0",
       "category": "development"
     }
   ]

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "willink-claude-kit",
-  "version": "2.2.0",
+  "version": "2.3.0",
   "description": "i-Willink 標準開発エージェント基盤。dev-explorer / dev-planner / dev-tester / dev-reviewer の 4 サブエージェント + 5 phase /build コマンドを Claude Code Plugin として提供。",
   "author": {
     "name": "i-Willink合同会社",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "willink-claude-kit",
-  "version": "2.2.0",
+  "version": "2.3.0",
   "description": "i-Willink 標準開発エージェント基盤を Codex でも使うための plugin。Claude Code 版を正本にし、Codex 向け adapter skill と同期チェックを提供する。",
   "author": {
     "name": "i-Willink合同会社",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes follow [Keep a Changelog](https://keepachangelog.com/en/1.1.
 
 ## [Unreleased]
 
+## [2.3.0] - 2026-07-18
+
+**Status**: 導入手順の致命的な欠陥を塞ぐリリース。README / adoption-guide がバージョン pin 例として案内していた `enabledPlugins` の array 単独形式は、`/plugin` 上「有効」と表示されたままコマンド・4 サブエージェント・全スキルを一切ロードしない状態を招いていた（**エラーも警告も出ない**ため実環境で約 6 日間検知されず）。指示に従った導入者ほど確実に壊れる性質のため、docs 修正に加えて「インストール済みか」ではなく「実際にロードされているか」を検査する doctor と、危険なスニペットの docs 再混入を CI で止める回帰ロックを同梱する。**既存導入者は本版へ更新後、自身の `settings.json` の `enabledPlugins` が `["x.y.z"]` になっていないか確認し、`true` へ修正して再起動すること**（更新だけでは復旧しない）。
+
 ### Added
 - **導入 doctor `scripts/check-kit-enabled.sh`** — 「インストール済み」と「実際にロードされているか」を区別して検査する自己診断。`enabledPlugins` の値型（boolean / array / string / false / 未宣言）・`installed_plugins.json` の登録と installPath 実在・plugin.json の JSON 妥当性・commands/agents/skills の件数を検査し、問題ごとに具体的な fix を出して exit 1。`/plugin` の「有効」表示は silently-disabled 状態を検出できないため、導入直後と kit 更新後はこれを正とする。`CLAUDE_CONFIG_DIR` を尊重し user / project / project-local の 3 scope を走査。python3 stdlib のみ。
 - `scripts/test/test_install_docs.sh` — 導入ドキュメントが「kit を silently 無効化するスニペット」を再び配ることを CI で禁止する回帰ロック。README / adoption-guide には array 代入例と「必ず pin」の誤指示が現れないこと、警告と doctor への導線があること、failure-modes には逆に **NG ラベル付きで**同じ array 例が残ること（アンチパターンの教材を消さない）を検証。3 パターンの変異テストで rubber-stamp でないことを確認済み。

--- a/codex/sync-manifest.json
+++ b/codex/sync-manifest.json
@@ -1,11 +1,11 @@
 {
   "schemaVersion": 1,
-  "updatedAt": "2026-07-11",
+  "updatedAt": "2026-07-18",
   "sourceOfTruth": "Claude Code plugin files are canonical; Codex and Antigravity files are platform adapters checked for drift.",
   "canonicalFiles": [
     {
       "path": ".claude-plugin/plugin.json",
-      "sha256": "a5e2d67cbdc345fecb4d6a716ae6936799b3518d697d1cab88f5d3c77e5352a3",
+      "sha256": "b6e8d0c197e15db4b9ce637e42da5355b877ae51d18409b76f5901d6fc85ea80",
       "codexAdapters": [
         ".codex-plugin/plugin.json",
         "skills/codex-build/SKILL.md"
@@ -16,7 +16,7 @@
     },
     {
       "path": ".claude-plugin/marketplace.json",
-      "sha256": "085c537d14fde25593c69d16e5557ba63fa460e367ac3a48f9e38b5ef90f0c02",
+      "sha256": "fa7ad6e782e4e3a828713512953cc80cd432ec5c5343adb6664a36c18eed7e43",
       "codexAdapters": [
         ".codex-plugin/plugin.json",
         "skills/codex-build/SKILL.md"


### PR DESCRIPTION
`[Unreleased]` に積まれていた #39 を **v2.3.0** として確定するリリース PR。

## なぜ patch でなく minor か

docs 修正だけなら patch だが、利用者向けツール `scripts/check-kit-enabled.sh` を
後方互換のまま**追加**しているため SemVer 上 MINOR。

## なぜ配布が必要か

`marketplace.json` の `source.ref` が tag を指すため、**導入者の手元に入るのは main ではなく tag の中身**。
つまり tag を切らない限り、修正済み docs も doctor も既存導入者には永遠に届かない。

そして「必ず pin する」という誤指示に従った几帳面な導入者ほど、**今この瞬間も静かに壊れたまま**で
自力では気付けない。これを届ける手段がリリースしかない。

## 変更

| ファイル | 内容 |
|---|---|
| `.claude-plugin/plugin.json` | `2.2.0` → `2.3.0` |
| `.codex-plugin/plugin.json` | 同期 |
| `.claude-plugin/marketplace.json` | version + `source.ref` → `willink-claude-kit--v2.3.0` |
| `CHANGELOG.md` | `[Unreleased]` → `## [2.3.0] - 2026-07-18` |
| `codex/sync-manifest.json` | `check_sync.py --update` で再生成 |

## 検証

- `check_sync.py --check` exit 0（version / ref / CHANGELOG ヘッダの整合を強制）
- 回帰スイート **19 file ALL GREEN**

## リリース後に必要な周知（重要）

**更新だけでは既存の壊れた環境は復旧しない。** 利用者側で以下の両方が必要:

1. プラグインを v2.3.0 へ更新
2. 自分の `settings.json` の `enabledPlugins` が `["x.y.z"]` になっていたら `true` に直して**再起動**

doctor は 1 の後でないと届かないため、別途一報を推奨。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KSY7U76g6qP9HPLDYTe3dE