### PR TITLE
docs: 配布ポリシーに緊急パッチ例外を追加（自己判断は禁止）

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -46,7 +46,14 @@ docs/                  導入ガイド・検証プロトコル・stack 別注意
 
 - コミットは **Conventional Commits**（`feat:` / `fix:` / `docs:` / `chore:` 等）
 - `agents/` `skills/` `commands/` `.claude-plugin/` を変更したら、同コミット内で manifest を再生成して含める（後述）
-- 配布（tag push / GitHub Release / main への直接配信）は **human-only**。AI agent は実施しない
+- 配布（tag push / GitHub Release / main への直接配信）は原則 **human-only**。AI agent は実施しない
+  - **例外: 緊急パッチ**。既に配布済みの版が利用者に実害を与えている場合に限り agent の実施を許可する
+    （silently 無効化・インストール不能・セキュリティ問題など。→ [failure-modes #11](docs/failure-modes.md) が実例）
+  - ただし **緊急かどうかを agent が自己判断してはならない**。人がそのセッションで明示的に指示した場合にのみ実施する。
+    自己申告による例外適用は禁止（`/pulse` の「自己申告禁止」と同じ規律 — 例外の発動条件を agent 自身に
+    握らせると、例外が規則を飲み込む）
+  - 緊急パッチでも **patch / minor に限る**（major は必ず人手）。CI 全 green が前提
+  - 実施後は「何を・どの tag で配布したか」を必ず報告する
 
 ## テスト
 


### PR DESCRIPTION
配布は原則 human-only のまま、**緊急パッチに限り agent の実施を許可**する例外を追加。

## 設計上のポイント

「緊急の場合は agent も可」とだけ書くと、**緊急かどうかの判断を agent 自身が握る**ことになり、
例外が規則を飲み込む。そこで発動条件を人側に固定した:

> 緊急かどうかを agent が自己判断してはならない。人がそのセッションで明示的に指示した場合にのみ実施する。

これは kit 自身が `/pulse` で課している **「自己申告禁止」** と同じ規律で、
「判定を実行者に握らせない」という Generator-Verifier 分離の考え方に沿う。

## 追加した制約

| 項目 | 内容 |
|---|---|
| 適用範囲 | 配布済みの版が利用者に実害を与えている場合（silently 無効化 / インストール不能 / セキュリティ） |
| 発動主体 | **人のみ**。agent の自己判断は禁止 |
| バージョン | patch / minor に限る（major は必ず人手） |
| 前提 | CI 全 green |
| 事後 | 何をどの tag で配布したかを必ず報告 |

実例として `docs/failure-modes.md` #11（今回の silent-disable）へリンクしている。

## 検証

- `check_sync.py --check` exit 0
- 回帰スイート 19 file ALL GREEN

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KSY7U76g6qP9HPLDYTe3dE