### PR TITLE
docs(ci): dependabot auto-merge の security invariant を明文化

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,5 +1,25 @@
 name: Dependabot Auto-Merge
 
+# SECURITY INVARIANTS — do not relax without understanding why they exist.
+#
+# `pull_request_target` runs in the context of the BASE repo: it gets this file's
+# write permissions and repo secrets even when the PR comes from a fork. That is
+# required here (a `pull_request` run from a fork would get a read-only token and
+# could not enable auto-merge), but it means the guards below are the only thing
+# standing between an untrusted fork PR and a `contents: write` token on a public repo.
+#
+#   1. The `github.actor == 'dependabot[bot]'` guard MUST stay. It is what keeps this
+#      job from running on arbitrary fork PRs. Widening it (e.g. to all bots, or
+#      dropping it) hands write access to anyone who can open a PR.
+#   2. NEVER add `actions/checkout` of the PR head (`github.event.pull_request.head.*`)
+#      to this workflow. Checking out untrusted code in a `pull_request_target` job is
+#      the classic path to arbitrary code execution with the elevated token.
+#   3. Keep `permissions:` at the minimum this job needs. It must never gain
+#      `workflows: write` — that would let a merged change rewrite CI itself.
+#
+# Distribution is human-only (see CLAUDE.md); this workflow deliberately cannot
+# create tags or releases. Release tags are additionally protected by a repo ruleset.
+
 on: pull_request_target
 
 permissions:
@@ -9,6 +29,7 @@ permissions:
 jobs:
   auto-merge:
     name: auto-merge patch+minor
+    # Guard 1 above — the sole barrier against fork PRs reaching the elevated token.
     if: github.actor == 'dependabot[bot]'
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
権限監査の一環。挙動の変更はなく**コメントのみ**。

## なぜ

`dependabot-auto-merge.yml` は `pull_request_target` で走るため、**fork の PR に対しても
base repo の `contents: write` トークンとシークレットが乗る**。public repo なので、
これを止めているのは実質 `github.actor == 'dependabot[bot]'` の 1 行だけ。

現状は安全（actor で絞られ、PR head の checkout もしていない）だが、
**なぜその 1 行が必要かがファイル上に書かれていなかった**。理由の書かれていない
ガードは将来ゆるめられる。

## 明文化した不変条件

1. `github.actor == 'dependabot[bot]'` を外す／広げない — fork PR に write トークンを渡すことになる
2. PR head の `actions/checkout` を追加しない — 昇格トークンでの任意コード実行の典型経路
3. `workflows: write` を足さない — CI 自体を書き換え可能になる

併せて「配布は human-only（CLAUDE.md）であり、この workflow は tag / release を作れない」旨も記載。
release tag は別途 ruleset で保護済み。

## 検証

- YAML パース OK（`permissions` / `if` 条件に変更なしを確認）
- 回帰スイート 19 file ALL GREEN / `check_sync.py --check` exit 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KSY7U76g6qP9HPLDYTe3dE