### PR TITLE
feat(a11y): アクセシビリティを既定で設計する 3 層（契約 + 決定論ゲート + 実行時テスト）

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,30 @@ All notable changes follow [Keep a Changelog](https://keepachangelog.com/en/1.1.
 
 ## [Unreleased]
 
+### Added
+- **アクセシビリティを「設計時の既定」にする 3 層** — 「a11y に配慮する」という自然言語の指示は確率的で、しかも失敗が書いた本人に見えない（見た目はボタンのままなので気づけない）。ハーネスの H1→H3 ラダーを UI 面にも適用する。
+  - `skills/a11y-standards/SKILL.md`（H1・契約）— accessible name / role / state の三点セット + 文字拡大 200%（iOS AX5 ≒ 3.12x）+ コントラスト + ターゲットサイズ + キーボードを 10 行の DoD にし、Flutter / React(Next.js) / WordPress(PHP) の「正解と典型的な誤り」を対照で示す。**4 agent が preload** し、`/build` Phase 2 は UI 変更時に要素ごとの name/role/state を計画に書かせる（UI 非変更なら `a11y: N/A` を明示 — 空欄は「検討していない」と同じ）。対外的に「WCAG AA 準拠」と書ける条件（人手監査 + Level 3 承認）も線引きした。
+  - `skills/a11y-static-gate/SKILL.md` + `scripts/a11y-static-check.py`（H3・決定論ゲート）— 括弧/タグのスタックと祖先チェーンを解析し、「この tappable を包む祖先にラベルがあるか」に正しく答える（行ウィンドウ grep は両方向に誤る）。rule 20 種（`A11Y-FLUTTER-NAME/ROLE/SYMBOL-LABEL/STATE/FIELD-NAME/TOGGLE-NAME/IMAGE-LABEL/SCALE-CLAMP/UNKNOWN-TAP-CTOR` ・ `A11Y-WEB-*` ・ `A11Y-MARKUP-*` ・ `A11Y-PROJ-*`）。stdlib python3 のみ・gh/aws/git に依存しない・**検出のみで修正も CI への自己配線もしない**。exit `0/1/2/3` で **3 = 走査 0 件 = UNKNOWN**（空スキャンを「違反ゼロ」に倒さない）。件数出力は常に分母（走査ファイル数・拡張子別・検査した操作要素数・rule 別・上位ファイル）を伴う。
+  - **baseline + ratchet**（レガシー導入）— 違反が既にある repo で「違反 0」を要求するとゲートは翌日外されるので、現状を凍結し新規違反のみ落とす。fingerprint は内容ベース（行がずれても再発火しない）。`--update-baseline` は**件数が増える更新を拒否**し、増やすには `--allow-baseline-growth` が要る（`coverage-floor-lock` の「floor を下げる diff 自体が違反」と同じ規律）。抑制は**理由付きの `a11y-ignore: <理由>` のみ**有効で、裸の pragma は抑制せず件数として報告される。
+  - `examples/a11y/flutter/a11y_smoke_test.dart` — 組込 4 ガイドライン + **組込では検出できない 2 つを塞ぐ自作ガイドライン**（`ButtonRoleGuideline` / `MeaningfulLabelGuideline`）+ iOS AX5（`53/17` ≒ 3.12・engine 実測値。3.0 では範囲上端を検査できない）と Android 200% での overflow 検査 + 読み上げ順アサート。**Flutter 3.44.2 で実走して検証**: 違反 fixture を fail（role 欠落 2 件 / 記号ラベル / タップ 24px / overflow 254px・64px）、修正 fixture を全 pass。
+  - `examples/a11y/web/eslint-a11y.config.md` — jsx-a11y の**明示有効化と error 昇格**（`eslint-config-next` は一部ルールを warn で入れるだけなので exit 0 になる）・lint 設定自体の生存確認 fixture・axe（light/dark 2 周・`target-size` は既定 off・`incomplete` も出す）・320px/200% の reflow 検査。
+  - `examples/ci/a11y-gate-pattern.md` ・ `examples/a11y/a11y-baseline.example.json` ・ `docs/a11y-guide.md`（新規/レガシーの導入手順、信用してはいけない指標、Apple の Accessibility Nutrition Labels と WordPress Accessibility Ready の要件）。
+  - `scripts/test/test_a11y_static_gate.sh` — ゲートの exit code 契約・ratchet・baseline 成長拒否・走査 0 件 = UNKNOWN・境界（コードを書き換えない/CI に自己配線しない）を回帰ロック。ゲート自身の hermetic self-test は **46 checks**。
+
+### Changed
+- `skills/dev-standards/SKILL.md` に §3 アクセシビリティ（UI に触る全変更に適用・後付け禁止）を追加し、以降の節を採番し直した。
+- `agents/dev-planner.md` — 出力に `## A11y plan`（要素ごとの name/role/state・拡大時の振る舞い・検証手段）を追加し、`a11y-standards` を preload。
+- `agents/dev-reviewer.md` — レビュー観点に Accessibility を追加。**UI 差分での name/role 欠落は LOW ではなく CRITICAL** として扱う（読み上げられないコントロールは壊れたコントロールで、パターンが複製されると全画面の欠陥になる）。
+- `agents/dev-tester.md` — UI 差分では a11y 静的ゲートと a11y テストも full run に含める（Flutter の overflow assert は release ビルドで消えるため debug 必須）。
+- `agents/dev-explorer.md` — UI 領域では「既存の操作要素がどう名前を得ているか（共通ボタン Widget か画面ごとの手書きか）」を報告させる。a11y 修正が 1 ファイルか 50 ファイルかを決める情報。
+- `commands/build.md` — Phase 2/4 に a11y を配線し、skip 表に「UI 追加/変更」行、失敗モードに「a11y の後付け」を追加。
+- `skills/codex-build/SKILL.md` ・ `skills/antigravity-build/SKILL.md` — 上記を各プラットフォームの実行モデルに反映（正本追従）。
+- `docs/harness-profile.md` — 決定論原則に「ユーザーに見える面も同じラダーに乗せる」を追加し、H1/H3 と採用チェックリスト・月次 KPI（baseline の `counts.error`）に a11y を追加。
+- `docs/stack-specific-notes.md` ・ `examples/project-standards-template/SKILL.md` ・ `README.md` — a11y の節を追加。
+
+### Fixed
+- `skills/antigravity-build/SKILL.md` の dev-standards 参照が作者のローカル絶対パス（`file:///Users/…`）だった。public OSS リポで外部利用者には解決できないリンクなので相対パスに修正。
+
 ## [2.3.0] - 2026-07-18
 
 **Status**: 導入手順の致命的な欠陥を塞ぐリリース。README / adoption-guide がバージョン pin 例として案内していた `enabledPlugins` の array 単独形式は、`/plugin` 上「有効」と表示されたままコマンド・4 サブエージェント・全スキルを一切ロードしない状態を招いていた（**エラーも警告も出ない**ため実環境で約 6 日間検知されず）。指示に従った導入者ほど確実に壊れる性質のため、docs 修正に加えて「インストール済みか」ではなく「実際にロードされているか」を検査する doctor と、危険なスニペットの docs 再混入を CI で止める回帰ロックを同梱する。**既存導入者は本版へ更新後、自身の `settings.json` の `enabledPlugins` が `["x.y.z"]` になっていないか確認し、`true` へ修正して再起動すること**（更新だけでは復旧しない）。

--- a/README.md
+++ b/README.md
@@ -9,7 +9,8 @@ Claude Code / Codex / Antigravity 向け標準開発エージェント基盤。C
 | 区分 | 内容 |
 |---|---|
 | **agents/** (4本) | `dev-explorer` / `dev-planner` / `dev-tester` / `dev-reviewer` — 公式 ガイドラインに沿って役割を厳選 |
-| **skills/dev-standards** | スタック非依存の汎用標準（TS strict / Conventional Commits / OWASP） |
+| **skills/dev-standards** | スタック非依存の汎用標準（TS strict / Conventional Commits / OWASP / a11y 最低ライン） |
+| **a11y を既定で設計する 3 層** (skills/ + scripts/ + examples/) | `a11y-standards`（設計時の契約 — 4 agent が preload し `/build` Phase 2 で name/role/state を決めさせる）+ `a11y-static-gate`（`scripts/a11y-static-check.py` — Flutter/React/PHP テンプレを横断して「支援技術から操作できない要素」を構造解析で検出。**baseline + ratchet** で既存レガシーにも導入でき、baseline を増やす更新は拒否）+ 実行時テストの雛形（`examples/a11y/` — Flutter は組込 4 ガイドライン + **組込では検出できない role 欠落/記号ラベルの自作ガイドライン** + iOS AX5/Android 200% での overflow 検査、Web は jsx-a11y/axe/reflow）。exit code は 0/1/2/**3=走査 0 件は UNKNOWN**。緑は「機械判定可能な違反ゼロ」であって「アクセシブル」とは言わない |
 | **commands/build.md** | 5 phase 版 `/build` フロー（探索→計画→実装→並列検証→修正/コミット） |
 | **commands/goal-loop.md** + **scripts/goal-loop\*.sh** | 組み込み `/goal` に「決定論 `--check` + 試行上限」の規律を足す停止プリミティブ。達成をモデルの自己申告でなく exit code で判定し N 回で必ず止める。雛形生成器 + `maker-checker-relay`（Generator↔Verifier=実装↔`dev-reviewer` レビューを分離して回す）付き。全て hermetic 自己テスト付き |
 | **skills/maker-checker-relay** | 実装（Maker）と読取専用レビュー（Checker=`dev-reviewer`/`/review`/人）を分離し「test 緑 かつ 指摘 0」まで反復する goal-loop ラッパー |
@@ -115,6 +116,7 @@ python3 scripts/check_sync.py --update
 - [docs/antigravity-adoption-guide.md](docs/antigravity-adoption-guide.md) — Antigravity 導入手順
 - [docs/verification-protocol.md](docs/verification-protocol.md) — 検証指標と記録テンプレ
 - [docs/stack-specific-notes.md](docs/stack-specific-notes.md) — Next.js / Flutter / WordPress 個別注意
+- [docs/a11y-guide.md](docs/a11y-guide.md) — a11y の導入手順（新規 / 既存レガシーの ratchet）・信用してはいけない指標・ストア/テーマ要件
 - [docs/failure-modes.md](docs/failure-modes.md) — Early victory / Telephone game 等の対策
 - [docs/hooks-guide.md](docs/hooks-guide.md) — hook の書き方・自己テスト・fail-open/closed・grep 移植性規約
 - [docs/harness-profile.md](docs/harness-profile.md) — 決定論的ゲートの導入プロファイル（H1-H4 ラダー・CI required check・昇格運用）

--- a/agents/dev-explorer.md
+++ b/agents/dev-explorer.md
@@ -35,6 +35,9 @@ Return a single markdown report with:
 
 ## Conventions observed
 <patterns the project actually uses, citing file paths>
+<for UI areas: how existing interactive elements get their accessible name/role — is there a shared button
+widget, or is every screen hand-rolling GestureDetector/div-onClick? This decides whether an a11y fix is one
+file or fifty.>
 
 ## Open questions
 <things you couldn't determine and why>

--- a/agents/dev-planner.md
+++ b/agents/dev-planner.md
@@ -1,9 +1,10 @@
 ---
 name: dev-planner
-description: i-Willink 開発タスクの実装計画を立案する。dev-standards / project-standards を preload した上で、影響範囲・実装ステップ・テスト戦略・ロールバック手順を提示。Use in /build Phase 2 when the task is non-trivial (>1 file or >50 lines). Skip for typo-level fixes.
+description: i-Willink 開発タスクの実装計画を立案する。dev-standards / a11y-standards / project-standards を preload した上で、影響範囲・実装ステップ・a11y 設計（name/role/state）・テスト戦略・ロールバック手順を提示。Use in /build Phase 2 when the task is non-trivial (>1 file or >50 lines). Skip for typo-level fixes.
 tools: Read, Glob, Grep, WebFetch
 skills:
   - dev-standards
+  - a11y-standards
   - project-standards
 ---
 
@@ -18,9 +19,11 @@ You are an implementation planner for i-Willink projects. You design *how* a cha
 ## How to operate
 
 1. Read `dev-standards` and `project-standards` (preloaded) to ground the plan in project conventions
-2. Read the directly affected files (don't re-do dev-explorer's work — build on top)
-3. Use WebFetch only when an external doc is the source of truth (RFC, library docs, API spec)
-4. Identify reuse opportunities — search for existing utilities/patterns before proposing new code
+2. If the task touches UI, read `a11y-standards` (preloaded) and decide accessible name / role / state per
+   element **in the plan** — retrofitting accessibility after implementation scatters the fix across every screen
+3. Read the directly affected files (don't re-do dev-explorer's work — build on top)
+4. Use WebFetch only when an external doc is the source of truth (RFC, library docs, API spec)
+5. Identify reuse opportunities — search for existing utilities/patterns before proposing new code
 
 ## Output format
 
@@ -42,6 +45,11 @@ You are an implementation planner for i-Willink projects. You design *how* a cha
 1. ...
 2. ...
 3. ...
+
+## A11y plan (UI changes only — write "N/A (no UI change)" otherwise)
+- <element>: name "<accessible name>" / role <button|link|textField|header> / state <enabled|toggled|selected: condition>
+- Large text: <how the layout behaves at 200% / iOS AX5 — which box must grow instead of clipping>
+- Verification: <static gate + which automated a11y test + what needs a device pass>
 
 ## Test strategy
 - Unit: <what to add/modify>

--- a/agents/dev-reviewer.md
+++ b/agents/dev-reviewer.md
@@ -1,9 +1,10 @@
 ---
 name: dev-reviewer
-description: 実装直後の差分を Evaluator として読取専用レビューする。仕様適合・コード品質・セキュリティ・i-Willink standards 準拠を判定し PASS / CONDITIONAL / FAIL を返す。指摘パターンを project memory に蓄積。Use in /build Phase 4 in parallel with dev-tester.
+description: 実装直後の差分を Evaluator として読取専用レビューする。仕様適合・コード品質・セキュリティ・アクセシビリティ・i-Willink standards 準拠を判定し PASS / CONDITIONAL / FAIL を返す。指摘パターンを project memory に蓄積。Use in /build Phase 4 in parallel with dev-tester.
 tools: Read, Glob, Grep, Bash
 skills:
   - dev-standards
+  - a11y-standards
   - project-standards
 memory: project
 ---
@@ -30,6 +31,11 @@ You are a senior code reviewer for i-Willink projects. You play the **Verifier**
 - **Code quality**: clear naming, no duplication, single responsibility
 - **Error handling**: only at boundaries (user input, external APIs); no defensive overkill
 - **Security**: no exposed secrets, OWASP top 10, input validation at boundaries
+- **Accessibility (UI diffs)**: every new/changed interactive element has an accessible name, a role and its
+  state. **Treat a missing name or role as CRITICAL, not LOW** — a control a screen reader cannot announce is
+  a broken control, and once the pattern is copied it becomes a whole-app defect. Also check: no symbol-only
+  labels (`<` `×` `…`), text fields named, images with alt/semanticLabel or explicitly marked decorative, and
+  nothing that breaks at 200% text. Say so explicitly when the diff has no UI change.
 - **Tests**: new code covered, tests actually exercise the behavior (not just happy path)
 - **Standards compliance**: TS strict / Conventional Commits / project-specific rules from `project-standards`
 - **Scope discipline**: no unrelated refactoring, no scope creep

--- a/agents/dev-tester.md
+++ b/agents/dev-tester.md
@@ -22,8 +22,15 @@ You are a verification runner for i-Willink projects. You execute the project's 
    - **Node/TS**: `lint` → `typecheck` → `test` → `build`
    - **Flutter**: `flutter analyze` → `flutter test` → `flutter build` (target as appropriate)
    - **WordPress/PHP**: `lint` (PHPCS) → `phpstan` (if configured) → `test`
-4. Run them **all** even if an early one fails. The full picture matters.
-5. Use Grep to extract specific failures from verbose output
+4. **If the diff touches UI**, also run the a11y layer and report it as its own line:
+   - static gate: `python3 scripts/a11y-static-check.py --root . [--baseline .a11y-baseline.json]`
+     (exit 0 no new findings / 1 new findings / 2 usage or missing baseline / **3 UNKNOWN = zero files
+     scanned, which is not a pass**)
+   - Flutter: the a11y widget test (`flutter test test/a11y_smoke_test.dart`) — run it in **debug**; the
+     overflow assert it relies on is compiled out of release builds
+   - Web: `eslint` (jsx-a11y) and the axe/reflow e2e test if the project has one
+5. Run them **all** even if an early one fails. The full picture matters.
+6. Use Grep to extract specific failures from verbose output
 
 ## Critical rule: no early victory
 
@@ -48,6 +55,7 @@ PASS | PARTIAL | FAIL
 - `pnpm typecheck` — exit 1 (12s) — see failures below
 - `pnpm test` — exit 0 (45s, 127 passed, 0 failed, 3 skipped)
 - `pnpm build` — exit 0 (38s)
+- `python3 scripts/a11y-static-check.py --root .` — exit 1 (0.7s, 86 files scanned, 3 new findings)
 
 ## Failures
 ### typecheck

--- a/codex/sync-manifest.json
+++ b/codex/sync-manifest.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
-  "updatedAt": "2026-07-18",
+  "updatedAt": "2026-07-25",
   "sourceOfTruth": "Claude Code plugin files are canonical; Codex and Antigravity files are platform adapters checked for drift.",
   "canonicalFiles": [
     {
@@ -27,7 +27,7 @@
     },
     {
       "path": "commands/build.md",
-      "sha256": "5394ba0f2a552c2e97662e7232be09e25820aa8dcd5f6f5fa39fd87130da633a",
+      "sha256": "a7e4577296ae8455d8cf381a1348b0ccbbc8cef8ca7cd8ef5783c30afe26cff2",
       "codexAdapters": [
         "skills/codex-build/SKILL.md",
         "docs/codex-adoption-guide.md"
@@ -38,7 +38,7 @@
     },
     {
       "path": "agents/dev-explorer.md",
-      "sha256": "78c808d1f5e9ac43edd102631872ab73d59f29afbb5e65d950afcd6432a31990",
+      "sha256": "18c0c88b58ae19463cf53462e42ed4c36198844dbbdfed0d7bd8ce2f8e2f225f",
       "codexAdapters": [
         "skills/codex-build/SKILL.md"
       ],
@@ -48,7 +48,7 @@
     },
     {
       "path": "agents/dev-planner.md",
-      "sha256": "e1eaccd84b1efeafcf3be4e8c9aa5d4d3b78e182428f1d3f6e6826c88462027f",
+      "sha256": "ba10804471161607f0ebd73130feb43e011853276ff4c1d279fbac0f475dd001",
       "codexAdapters": [
         "skills/codex-build/SKILL.md"
       ],
@@ -58,7 +58,7 @@
     },
     {
       "path": "agents/dev-tester.md",
-      "sha256": "66507807a0a76fef6937c1a2a7bceb6e008d417b7544fb04f2db7de024de2e72",
+      "sha256": "1b2df8b45c1ebc67db1cb80f36c6d7506513370220a9fda4561fec31baee9fc9",
       "codexAdapters": [
         "skills/codex-build/SKILL.md"
       ],
@@ -68,7 +68,7 @@
     },
     {
       "path": "agents/dev-reviewer.md",
-      "sha256": "b9b5c6f425279fb7594f0dade7112b42083aa75c30033ac471be20b15cc9c57e",
+      "sha256": "6a73c8b63e3f5843b6e1b1d274567637b6161a1687cd2d58f0fd22ca12b0bdc7",
       "codexAdapters": [
         "skills/codex-build/SKILL.md",
         "docs/codex-adoption-guide.md"
@@ -79,7 +79,7 @@
     },
     {
       "path": "skills/dev-standards/SKILL.md",
-      "sha256": "432e191bc7fa21778b0d1a1e5289998c44724917c07448dd7936e1d90aaeffa1",
+      "sha256": "8e247b49bb6466ec75dcd2d5c498e0e772ba9686a12f51aaa31b3cb8c254c876",
       "codexAdapters": [
         "skills/codex-build/SKILL.md",
         "docs/codex-adoption-guide.md"

--- a/commands/build.md
+++ b/commands/build.md
@@ -30,6 +30,8 @@ dev-planner に Phase 1 の結果と要件を渡し、実装計画を受け取�
 
 返ってくる計画には: ファイル別変更内容 / 既存ユーティリティ再利用 / 実装ステップ / テスト戦略 / ロールバック手順。
 
+**UI を触る変更では a11y を計画段階で決める**（後付けは全画面に散る修正になる）。新規/変更する操作要素ごとに accessible name / role / state と、文字拡大時の振る舞いを計画に明記する。UI 非変更なら「a11y: N/A」と書く — 空欄は「検討していない」と同じ。基準は `a11y-standards` skill。
+
 ## Phase 3: 実装（メイン Claude）
 
 **メイン Claude が Edit/Write で実装する**。subagent には委譲しない（Generator-Verifier 構造を保つ・差分の責任所在を明確化）。
@@ -46,7 +48,9 @@ dev-planner に Phase 1 の結果と要件を渡し、実装計画を受け取�
 
 ```
 dev-tester:    test / lint / typecheck / build を full run → PASS/PARTIAL/FAIL
+               UI 差分があれば a11y ゲート（scripts/a11y-static-check.py）+ a11y テストも回す
 dev-reviewer:  diff を読取専用レビュー → PASS/CONDITIONAL/FAIL
+               UI 差分では name/role/state の欠落を CRITICAL として扱う
 ```
 
 両者の判定マトリクス:
@@ -84,6 +88,7 @@ git commit -m "<type>(<scope>): <subject>
 | 新機能（小） | skip | 起動 | 並列 |
 | 新機能（大） | 起動 | 起動 | 並列 |
 | リファクタ | 起動 | 起動 | 並列 |
+| **UI 追加/変更** | 影響範囲次第 | **必ず起動**（a11y 設計を含む） | 並列 + **a11y ゲート** |
 | ドキュメント | skip | skip | skip |
 
 ---
@@ -95,6 +100,7 @@ git commit -m "<type>(<scope>): <subject>
 - **Options flooding**: 4 agent に厳選（追加禁止）
 - **Subagent コスト爆発**: Phase 1 並列は 3 軸以上独立な時のみ
 - **同一ファイル並列編集**: Phase 4 は read-only agent のみ並列
+- **a11y の後付け**: UI は Phase 2 で name/role/state を決める（実装後の監査で足すと修正が全画面に散る）
 
 ---
 
@@ -102,5 +108,6 @@ git commit -m "<type>(<scope>): <subject>
 
 - agents/ — dev-explorer / dev-planner / dev-tester / dev-reviewer 定義
 - skills/dev-standards/ — 共通開発標準
+- skills/a11y-standards/ ・ skills/a11y-static-gate/ — UI 変更時の a11y 設計標準と決定論ゲート
 - docs/failure-modes.md — 失敗モード詳細
 - docs/adoption-guide.md — 導入手順

--- a/docs/a11y-guide.md
+++ b/docs/a11y-guide.md
@@ -1,0 +1,172 @@
+# Accessibility — 既定で設計し、決定論的に守る
+
+「アクセシビリティに配慮する」は指示としては確率的で、守られたか確認できない。この kit は
+a11y を 3 層で扱う: **設計時の契約**（[`a11y-standards`](../skills/a11y-standards/)）→
+**毎コミットの決定論ゲート**（[`a11y-static-gate`](../skills/a11y-static-gate/)）→
+**実行時テストと実機**（`examples/a11y/`）。
+
+- 何を守るか → [`skills/a11y-standards/SKILL.md`](../skills/a11y-standards/SKILL.md)
+- どう機械判定するか → [`skills/a11y-static-gate/SKILL.md`](../skills/a11y-static-gate/SKILL.md)
+- CI 配線と ratchet → [`examples/ci/a11y-gate-pattern.md`](../examples/ci/a11y-gate-pattern.md)
+
+本書は**導入手順**と、そこに至った**実測の根拠**を扱う。
+
+---
+
+## 1. なぜ後付けが効かないか（この標準の出発点）
+
+社内の Flutter 製チャットアプリで a11y 監査を行った結果:
+
+- 操作要素のほぼ全てが「`GestureDetector` + `Text`/`Container` の自作ボタン」で、**button role を持たない**
+- 戻る導線は記号 `<` を表示しており、読み上げは「**小なり**」
+- アイコン導線（日記/設定/追加）は**ラベルが無く無名の要素**として読まれる
+- 明示的な `Semantics` はチャット気泡系の数ノードのみ
+- 端末の文字サイズを最大にすると、固定寸法のメッセージカードが **RenderFlex overflow**
+
+→ 結論は「音声のみでの通し操作（ログイン → ペア設定 → 送受信）が成立しない」。
+
+重要なのは**個々のバグではなく分布**で、共通ボタン Widget が name/role を持たないために
+**全画面が同時に壊れていた**。逆に言えば、共通 Widget 1 ファイルに name/role/state を入れると
+主要画面が一斉に治る。だから a11y は「設計時に 1 回決める」ものとして扱う。
+
+このリポジトリの静的ゲートは、上記の監査結果を**独立に再現**する（共通ボタン Widget の該当行、
+記号ラベルの戻るボタン 9 箇所、無名アイコン導線を検出）。しかも監査所見より精密で、
+「コピー/共有ボタンはラベル欠落」ではなく「**ラベルはあるが role/state が欠落**」と分類した。
+
+---
+
+## 2. 新規プロジェクトへの導入（違反 0 が前提）
+
+```bash
+# 1. ゲートを回す（stdlib python3 のみ・依存なし）
+python3 scripts/a11y-static-check.py --root .
+
+# 2. 実行時テストを置く
+cp examples/a11y/flutter/a11y_smoke_test.dart <project>/test/a11y_smoke_test.dart   # Flutter
+#   examples/a11y/web/eslint-a11y.config.md の設定を eslint / axe に反映            # Web
+
+# 3. project-standards に「このプロジェクトの具体値」を書く
+#    （共通ボタン Widget 名・対応 AT・クランプ値・除外領域とその理由）
+```
+
+CI は [`examples/ci/a11y-gate-pattern.md`](../examples/ci/a11y-gate-pattern.md) の形。
+`|| true` と `continue-on-error` を付けない（付けた瞬間にゲートは装飾になる）。
+
+## 3. 既存（レガシー）プロジェクトへの導入
+
+違反が既に 50 件あるリポジトリに「違反 0」を要求すると、翌日ゲートが外される。
+**現状を凍結して、増分だけを止める**。
+
+```bash
+# 現状を baseline に固定（PR に件数を書いて債務を記録する）
+python3 scripts/a11y-static-check.py --root . \
+    --baseline .a11y-baseline.json --update-baseline
+git add .a11y-baseline.json
+```
+
+- 以後 CI は `--baseline .a11y-baseline.json` 付きで回し、**新規違反のみ落ちる**
+- baseline は**減る方向にのみ**更新できる（増やすには `--allow-baseline-growth` が必要で、
+  痕跡が diff と PR に残る）
+- **baseline は必ずスキャナ自身の出力から作る**。監査レポートの件数を手で転記しない
+  （grep 行数ベースの件数は二重計上を含み、実際の distinct な違反数と一致しない）
+- 修正の順序: ①共通 Widget / 共通コンポーネント（1 箇所で全画面に効く）→ ②主要導線
+  （ログイン・課金・問い合わせ）→ ③残り
+
+月次で見る数値は baseline の `counts.error` 1 つ。単調減少が期待値。
+
+---
+
+## 4. 「対応済み」と言える範囲（表記の線引き）
+
+自動検出でカバーできるのは違反の一部（Deque の調査で issue 件数ベース約 57%）。
+したがって:
+
+| 書ける | 書けない（人手監査 + 社長承認が必要 = Level 3） |
+|---|---|
+| 「機械判定可能な a11y 違反ゼロ（走査 N ファイル）」 | 「WCAG 2.2 AA 準拠」 |
+| 「VoiceOver で主要導線を通しで確認済み（日付・端末・OS 版）」 | 「アクセシブル」「フルアクセシビリティ対応」 |
+
+受託契約・LP・ストア申告に準拠表記を載せるのは法的リスクを伴う。ゲートの緑は
+**準拠の証明ではない**。
+
+### 特に信用してはいけない指標
+
+- **Lighthouse の accessibility スコア**: 自動監査と manual 監査で構成され、**manual 側はスコアに
+  影響しない**。その manual 項目が `custom-controls-labels` / `custom-controls-roles` /
+  `focusable-controls` / `logical-tab-order` ＝まさに「自作ボタンに role が無い」系なので、
+  **スコア 100 と「読み上げで操作不能」は両立する**
+- **Flutter 組込の `labeledTapTargetGuideline`**（実測・Flutter 3.44.2）: label **または tooltip** が
+  非空なら通る。**role を見ない**し、`Text('<')` も**非空ラベルとして通す**。つまり §1 の
+  2 大欠陥はこのガイドラインでは緑になる
+- **axe / eslint-plugin-jsx-a11y**: アイコンのみボタンと記号ラベル（`×`）を検出しない
+  （axe は「discernible text あり」として合格させる）
+- **空の実行結果**: 走査 0 件は「違反 0」ではない。ゲートはこれを exit 3（UNKNOWN）で返す
+
+---
+
+## 5. プラットフォーム側の要件（事業インパクト）
+
+### Apple — Accessibility Nutrition Labels
+
+App Store の製品ページに申告する 9 項目（VoiceOver / Voice Control / Larger Text /
+Dark Interface / Differentiate Without Color Alone / Sufficient Contrast / Reduced Motion /
+Captions / Audio Descriptions）。**現状は任意だが、Apple は将来必須化を明言**している
+（「over time, you'll be required to share accessibility support details to submit new apps and
+app updates」）。判定単位は「common tasks」（primary functionality / first launch / login /
+purchase / settings）で、**その全てで機能が使えないと申告できない**。
+
+- 申告は App Store Connect の App Accessibility でデバイス単位（App Store Connect API にも
+  `accessibility-declarations` エンドポイントがある）
+- **Larger Text の条件は「200% または システム最大まで拡大できる」**。したがって
+  文字拡大を 2.0 未満にクランプすると申告できない（ゲートの `A11Y-FLUTTER-SCALE-CLAMP` がこれを見る）
+- VoiceOver の評価基準は**ラベルとトレイト（role/state）を明確に分離**することを要求する
+  （「Labels should NOT include control types like 'checkbox' or states like 'checked'」）
+- App Store Review Guidelines 本体に a11y の要求条項は無い。ただし **editorial featuring の
+  公式観点 7 つのうち 1 つが Accessibility**（"A great experience for a broad range of users with
+  well integrated features."）。Featuring Nominations は最低 3 週間のリードタイム
+
+出典: https://developer.apple.com/help/app-store-connect/manage-app-accessibility/overview-of-accessibility-nutrition-labels
+・ https://developer.apple.com/app-store/getting-featured/
+
+### WordPress — Accessibility Ready（受託テーマ）
+
+`accessibility-ready` タグを謳うテーマの要件は **2026-05-06 改訂で全 18 項目が必須**になり
+（旧「推奨」区分は廃止）、テーマルートに **`accessibility.txt`** を置くことも必須。
+対応期限は **2026-09-30** に延長され、**10 月 1 日以降、再レビュー未申請のテーマはディレクトリから
+de-list** される。
+
+- ただし公式が「`Accessibility Ready` は WCAG AA 準拠を意味しない」と明記している。
+  テーマレビューチームの**最低基準**であって、準拠表記の根拠にはならない
+- 数値要件: 本文 4.5:1 / 大きい文字 3:1 / UI 部品 3:1、フォーカスは**最小 2px の outline**、
+  reflow は 1280px 幅で 200%→400% ズームで横スクロールが出ないこと
+- フォームは**可視ラベル + `for`/`id` の明示的関連付け**が必須（placeholder は代替不可）
+- 本文中リンクは**下線必須**（色だけの区別は不可）。`read more` のような文脈依存テキストは不可
+- PHP 側に a11y の静的解析経路は実質存在しない（`WPThemeReview` は 2021 年に更新停止）。
+  この kit の静的ゲート（`A11Y-MARKUP-*`）＋ rendered DOM への axe の 2 層で埋める
+
+出典: https://wpaccessibility.org/docs/accessibility-ready/theme-guidelines/
+・ https://make.wordpress.org/accessibility/2026/07/23/accessibility-ready-theme-reviews-extending/
+
+---
+
+## 6. 静的ゲートの限界（正直な記載）
+
+- **ラッパー越しは見えない**: 共通ボタン Widget 経由の呼び出し側は検査対象にならない。
+  ゲートは**ラッパー定義そのもの**を検出し、加えて「分類できない tappable コンストラクタ」を
+  `A11Y-FLUTTER-UNKNOWN-TAP-CTOR`（warn・ファイル単位で集約）として**必ず可視化**する
+  — ハードコードした既知リストのドリフトを黙って通さないための設計
+- **動的に組まれるラベル**は「名前がある」として扱う（過検出を避けるため）。実際に意味のある語かは
+  人手判断
+- **CSS のカスケード**は静的に解けない（`outline: none` の復活検出などは advisory 止まり）
+- **`--release` では overflow の assert が消える**ため、Flutter の拡大テストは debug でのみ有効
+- ゲートは検出のみで、**修正も CI への自己配線もしない**
+
+---
+
+## 7. 関連
+
+- [`skills/a11y-standards/`](../skills/a11y-standards/) — 設計時の契約（agents が preload する）
+- [`skills/a11y-static-gate/`](../skills/a11y-static-gate/) — 決定論ゲートの rule 一覧と exit code
+- [`examples/a11y/flutter/a11y_smoke_test.dart`](../examples/a11y/flutter/a11y_smoke_test.dart) — 組込 4 ガイドライン + role/記号ラベルの自作ガイドライン + 最大文字サイズの overflow 検査
+- [`examples/a11y/web/eslint-a11y.config.md`](../examples/a11y/web/eslint-a11y.config.md) — jsx-a11y / axe / reflow
+- [`docs/harness-profile.md`](harness-profile.md) — 決定論ゲートのラダー（H1-H4）における a11y の位置

--- a/docs/harness-profile.md
+++ b/docs/harness-profile.md
@@ -9,9 +9,9 @@ home organization enforces in production (ADR-019).
 
 | Layer | What | Where in this kit |
 |---|---|---|
-| H1 | Docs / natural-language rules | `CLAUDE.md`, `examples/project-standards-template/` |
+| H1 | Docs / natural-language rules | `CLAUDE.md`, `examples/project-standards-template/`, [`a11y-standards`](../skills/a11y-standards/) |
 | H2 | AI semantic review | PR review agents (advisory) |
-| H3 | **Blocking verification** | hooks ([`docs/hooks-guide.md`](hooks-guide.md), [`examples/hooks/`](../examples/hooks/)) + CI required checks ([`examples/ci/`](../examples/ci/)) + deterministic gates (`skills/` coverage-floor-lock · token-codegen-gate · commit-convention-gate · self-heal-ci · live-state-verify-guard) |
+| H3 | **Blocking verification** | hooks ([`docs/hooks-guide.md`](hooks-guide.md), [`examples/hooks/`](../examples/hooks/)) + CI required checks ([`examples/ci/`](../examples/ci/)) + deterministic gates (`skills/` coverage-floor-lock · token-codegen-gate · commit-convention-gate · self-heal-ci · live-state-verify-guard · a11y-static-gate) |
 | H4 | Structural tests | architecture / parity tests — [`architecture-parity-gate`](../skills/architecture-parity-gate/) (config-declared dependency direction + layer naming) |
 
 Rules start at H1 and get **promoted** when violated repeatedly (2+ of the same kind).
@@ -28,6 +28,17 @@ Demoting or loosening a gate is a governance decision — require explicit human
 4. After every incident, add **one** verification that would have caught it.
 5. Documents count too: articles, reports and changelogs can be linted (tone, citations,
    measured-value markers) like code.
+6. **The user-facing surface counts too.** "Be accessible" is the most probabilistic instruction
+   in a codebase, and its failures are invisible to the person writing the code — the control
+   still looks like a button. So the same ladder applies: the contract is H1
+   ([`a11y-standards`](../skills/a11y-standards/)), the blocking check is H3
+   ([`a11y-static-gate`](../skills/a11y-static-gate/), which fails on an interactive element with
+   no accessible name / role / state), and the runtime tests live with the stack
+   ([`examples/a11y/`](../examples/a11y/)). Adopting it on a repo that already has violations uses
+   a **baseline + ratchet**: the known set is frozen, only new violations fail, and the baseline may
+   only shrink — the same anti-gaming shape as `coverage-floor-lock`, where lowering the floor is
+   itself the finding. Note what the gate does *not* claim: green means "no statically detectable
+   defect", never "accessible" — a screen-reader pass stays a human step.
 6. Read live state before you report it. Status / progress / "is it deployed?" claims must
    come from a live probe, not a document (docs are *plan*; live is *state*). The read-only
    [`/pulse`](../commands/pulse.md) command is the measurement layer for this profile — it
@@ -71,6 +82,11 @@ as consent — the same *empty output ≠ zero* discipline the rest of this prof
 
 ## Adoption checklist
 
+0. **a11y gate (any repo with a UI)** — run
+   `python3 scripts/a11y-static-check.py --root .`; if it already reports findings, freeze them with
+   `--baseline .a11y-baseline.json --update-baseline`, commit the baseline, and add the CI step from
+   [`examples/ci/a11y-gate-pattern.md`](../examples/ci/a11y-gate-pattern.md). Exit 3 = zero files
+   scanned = UNKNOWN, not a pass.
 1. **Hooks (local, fail-closed)** — copy [`examples/hooks/`](../examples/hooks/) into
    `.claude/hooks/` (`pre-bash-safety.sh` + `_strip-command.awk` for destructive commands,
    `pre-file-protect.sh` for `.env`/keys/`.git`/settings), wire into
@@ -91,3 +107,4 @@ as consent — the same *empty output ≠ zero* discipline the rest of this prof
 - Natural-language-only rules remaining (should trend down)
 - Required status checks across repos (should trend up)
 - Advisory → blocking promotions (with dates)
+- `counts.error` in each repo's `.a11y-baseline.json` (should trend down, never up)

--- a/docs/stack-specific-notes.md
+++ b/docs/stack-specific-notes.md
@@ -24,6 +24,11 @@ pnpm build       # Next.js build
 - Server Component で `useState` を使ってしまう
 - `'use client'` の付け忘れ／過剰付け
 - Image / Font の最適化漏れ
+- `<div onClick>` で押せる要素を作る（キーボード/支援技術から操作不能）・アイコンのみボタンに `aria-label` 無し
+
+### a11y
+`next lint` は jsx-a11y の**一部ルールを warn で**入れるだけなので、それだけでは exit 0。
+明示有効化 + error 昇格 + axe/reflow は [`examples/a11y/web/eslint-a11y.config.md`](../examples/a11y/web/eslint-a11y.config.md)。
 
 ---
 
@@ -43,7 +48,17 @@ flutter build ios     # or appbundle / web
 - DB 認可ポリシー（RLS 等）の管理場所と更新フロー
 - ネイティブ固有: 権限文言・consent modal の場所
 
+### a11y（Flutter は組込ガイドラインに穴がある）
+```bash
+python3 scripts/a11y-static-check.py --root .          # name/role/state・記号ラベル・クランプ値
+flutter test test/a11y_smoke_test.dart                 # 組込 4 + 自作 2 + 最大文字サイズ（debug のみ有効）
+```
+実測（3.44.2）: 組込 `labeledTapTargetGuideline` は **role を見ず**、`Text('<')` も通す。
+雛形は [`examples/a11y/flutter/a11y_smoke_test.dart`](../examples/a11y/flutter/a11y_smoke_test.dart)。
+
 ### よくある dev-reviewer 指摘
+- 生の `GestureDetector` で押せる要素を作り、`Semantics(button:true, label:…)` が無い（全画面に伝播する）
+- 固定高さのカードに文字を詰め、文字拡大でレイアウトが溢れる
 - DB 認可ポリシーが schema 追加に追従していない
 - `BuildContext` を async gap 越しに使う（mounted チェック漏れ）
 - ネイティブ SDK の権限を request せずに read 呼出
@@ -86,6 +101,12 @@ composer test          # PHPUnit (あれば)
 - PHP version 制約（古い案件は 7.4、新規は 8.x）
 - Atomic Design の category と命名規則
 - NDA に関わる情報は kit に書かない（NDA repo の内部のみ）
+
+### a11y（受託の品質差になりやすい）
+`img` の alt・空リンク・ラベル無しフォーム・`user-scalable=no`・正の `tabindex` は静的ゲートが見る。
+skip link / 見出し階層 / 本文リンクの下線 / フォーカス可視（2px）は人手。
+`accessibility-ready` を謳う場合の要件（2026-05-06 改訂で 18 項目必須・`accessibility.txt`・
+2026-09-30 期限）は [`a11y-guide.md`](a11y-guide.md#5-プラットフォーム側の要件事業インパクト) を参照。
 
 ### よくある dev-reviewer 指摘
 - `wp_unslash()` / `sanitize_*()` / `esc_*()` の境界処理漏れ

--- a/examples/a11y/a11y-baseline.example.json
+++ b/examples/a11y/a11y-baseline.example.json
@@ -1,0 +1,18 @@
+{
+  "schemaVersion": 1,
+  "note": "既知の a11y 違反スナップショット（ratchet 用）。新規違反のみ CI を落とす。件数は減る方向にのみ更新してよい — 増やす更新は --allow-baseline-growth が必要で、理由の記載が前提。scripts/a11y-static-check.py --root . --baseline .a11y-baseline.json --update-baseline で生成する。手で編集しない。",
+  "counts": {
+    "error": 3,
+    "warn": 1
+  },
+  "scanned": {
+    "files": 86,
+    "interactive": 67
+  },
+  "findings": [
+    "A11Y-FLUTTER-NAME|lib/screens/home_screen.dart|3f9a1c2d4e5b|1",
+    "A11Y-FLUTTER-ROLE|lib/widgets/common/app_button.dart|8b7c6d5e4f3a|1",
+    "A11Y-FLUTTER-SYMBOL-LABEL|lib/screens/detail_screen.dart|1a2b3c4d5e6f|1",
+    "A11Y-FLUTTER-STATE|lib/widgets/common/app_button.dart|9f8e7d6c5b4a|1"
+  ]
+}

--- a/examples/a11y/flutter/a11y_smoke_test.dart
+++ b/examples/a11y/flutter/a11y_smoke_test.dart
@@ -1,0 +1,275 @@
+// examples/a11y/flutter/a11y_smoke_test.dart
+//
+// Copy to `test/a11y_smoke_test.dart`, replace `appUnderTest()` with your screen,
+// and run `flutter test test/a11y_smoke_test.dart`. Plain `flutter test` — headless,
+// no GPU, no extra package.
+//
+// WHY the two custom guidelines exist (measured on Flutter 3.44.2, and the reason a
+// screen-reader defect can ship with every built-in guideline green):
+//
+//   * `labeledTapTargetGuideline` only checks that a tappable node's label OR tooltip
+//     is non-empty. It does NOT look at role, so
+//     `GestureDetector(onTap: .., child: Text('送信'))` PASSES while its semantics node
+//     reports `isButton == false` — the screen reader never says "button".
+//     → ButtonRoleGuideline below closes that hole.
+//   * The same guideline accepts ANY non-empty label, so a back button rendered as
+//     `Text('<')` PASSES — VoiceOver reads "less than".
+//     → MeaningfulLabelGuideline below closes that hole.
+//
+// Both holes are also caught statically (before the test even runs) by the kit's
+// `a11y-static-gate` (A11Y-FLUTTER-ROLE / A11Y-FLUTTER-SYMBOL-LABEL). The static gate
+// finds them per source line; these guidelines find them in the rendered semantics
+// tree. Keep both: neither subsumes the other.
+//
+// SDK floor: `flagsCollection` requires Flutter >= 3.32 (it replaced the now-deprecated
+// `SemanticsData.hasFlag`). Verified end-to-end on Flutter 3.44.2 / Dart 3.12.2: the two
+// custom guidelines FAIL a GestureDetector-with-Icon / Text('<') / unroled-Text screen
+// and PASS the corrected one. On Flutter < 3.32 swap `flagsCollection.isButton` for
+// `data.hasFlag(SemanticsFlag.isButton)` and drop the Tristate comparisons.
+//
+// References
+//   https://docs.flutter.dev/ui/accessibility/accessibility-testing
+//   https://api.flutter.dev/flutter/flutter_test/AccessibilityGuideline-class.html
+//   https://docs.flutter.dev/release/breaking-changes/deprecate-textscalefactor
+//   https://docs.flutter.dev/release/breaking-changes/android-14-nonlinear-text-scaling-migration
+
+import 'dart:async';
+import 'dart:ui' show Tristate;
+
+import 'package:flutter/material.dart';
+import 'package:flutter/rendering.dart';
+import 'package:flutter/semantics.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+// ---------------------------------------------------------------------------
+// TODO(project): return the widget you want audited — ideally the real app root,
+// or one screen at a time for a large app.
+// ---------------------------------------------------------------------------
+Widget appUnderTest() => const MaterialApp(home: Placeholder());
+
+/// iOS largest Dynamic Type (AX5). The engine reports body 53pt over the default
+/// 17pt, i.e. ~3.12 — NOT 3.0. Testing at 3.0 leaves the top of the range untested.
+/// (engine: FlutterViewController.mm `-textScaleFactor`, ax5 = 53, l = 17)
+const double kIosAx5TextScale = 53.0 / 17.0; // ≈ 3.1176
+
+/// Android's documented maximum for testing is 200%. Android 14+ scales text
+/// non-linearly, so a linear 2.0 is an approximation of the top of the range.
+const double kAndroidMaxTextScale = 2.0;
+
+void main() {
+  group('a11y — built-in guidelines', () {
+    testWidgets('tap target size, labels and text contrast', (tester) async {
+      final SemanticsHandle handle = tester.ensureSemantics(); // required, else null assert
+      await tester.pumpWidget(appUnderTest());
+      await tester.pumpAndSettle();
+
+      // 48x48 (Android) is also what Flutter's own release checklist asks for, so it
+      // is the stricter of the two and worth keeping even on an iOS-only app.
+      await expectLater(tester, meetsGuideline(androidTapTargetGuideline));
+      await expectLater(tester, meetsGuideline(iOSTapTargetGuideline));
+      await expectLater(tester, meetsGuideline(labeledTapTargetGuideline));
+      await expectLater(tester, meetsGuideline(textContrastGuideline));
+
+      handle.dispose();
+    });
+
+    testWidgets('every tappable node declares a role and a meaningful label',
+        (tester) async {
+      final SemanticsHandle handle = tester.ensureSemantics();
+      await tester.pumpWidget(appUnderTest());
+      await tester.pumpAndSettle();
+
+      await expectLater(tester, meetsGuideline(const ButtonRoleGuideline()));
+      await expectLater(tester, meetsGuideline(const MeaningfulLabelGuideline()));
+
+      handle.dispose();
+    });
+  });
+
+  group('a11y — largest text size', () {
+    // A RenderFlex overflow is reported through FlutterError inside a debug-mode
+    // assert, and `flutter test` runs in debug — so `tester.takeException()` turns
+    // "the layout breaks at the largest font size" into a failing test.
+    //
+    // Measured caveat 1: `MediaQuery.withClampedTextScaling(maxScaleFactor: 1.6)` did
+    // NOT fix a fixed-height box (76px overflow became 16px). Clamping is mitigation;
+    // making the box grow with its content is the fix. And clamping BELOW 2.0 is itself
+    // a WCAG 1.4.4 violation (200% must remain usable), so `maxScaleFactor: 2.0` is the
+    // floor — the static gate flags anything lower (A11Y-FLUTTER-SCALE-CLAMP).
+    //
+    // Measured caveat 2: the overflow assert only exists in debug builds. `flutter test`
+    // is debug, so this works — but running the same test with `--release` strips the
+    // assert and the check goes quietly green. Never gate on a release-mode run.
+    //
+    // Measured caveat 3 (the limit of this check): it catches *RenderFlex* overflow —
+    // a Column/Row whose children no longer fit — which is the common failure. Text
+    // that simply gets clipped inside a fixed `SizedBox` raises no FlutterError and so
+    // passes here. Verified: Column-in-a-56px-box fails at 254px (AX5) / 64px (200%),
+    // while a bare over-tall Text in a SizedBox does not. Screenshot review at the
+    // largest size is still required.
+    for (final scale in <String, double>{
+      'iOS AX5 (${kIosAx5TextScale.toStringAsFixed(2)}x)': kIosAx5TextScale,
+      'Android 200%': kAndroidMaxTextScale,
+    }.entries) {
+      testWidgets('no overflow at ${scale.key}', (tester) async {
+        await tester.pumpWidget(
+          MediaQuery(
+            data: MediaQueryData(textScaler: TextScaler.linear(scale.value)),
+            child: appUnderTest(),
+          ),
+        );
+        await tester.pumpAndSettle();
+        expect(
+          tester.takeException(),
+          isNull,
+          reason: 'レイアウトが最大文字サイズで溢れている。固定高さを可変にするか '
+              'FittedBox で内容を縮小フィットさせる（クランプは緩和策で修正ではない）',
+        );
+      });
+    }
+  });
+
+  group('a11y — reading order of the critical path', () {
+    // simulatedAccessibilityTraversal() models the order assistive technology walks
+    // the tree. It is an approximation (the docs say so) — it protects the ORDER, it
+    // does not replace a device pass with VoiceOver / TalkBack.
+    testWidgets('the primary flow is reachable in a sensible order', (tester) async {
+      final SemanticsHandle handle = tester.ensureSemantics();
+      await tester.pumpWidget(appUnderTest());
+      await tester.pumpAndSettle();
+
+      final labels = tester.semantics
+          .simulatedAccessibilityTraversal()
+          .map((node) => node.label)
+          .where((label) => label.isNotEmpty)
+          .toList();
+
+      // TODO(project): assert the labels a screen-reader user must hit, in order.
+      //   expect(
+      //     tester.semantics.simulatedAccessibilityTraversal(),
+      //     containsAllInOrder(<Matcher>[
+      //       containsSemantics(label: '戻る', isButton: true),
+      //       containsSemantics(label: 'メッセージを入力', isTextField: true),
+      //       containsSemantics(label: '送信', isButton: true, isEnabled: true),
+      //     ]),
+      //   );
+      expect(labels, isNotEmpty, reason: '読み上げ対象のラベルが 1 つも無い');
+
+      handle.dispose();
+    });
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Custom guidelines — the gaps the built-ins leave open
+// ---------------------------------------------------------------------------
+
+/// Fails when a semantics node has a tap/long-press action but declares no role.
+/// A custom `GestureDetector` button is announced as plain text without this.
+class ButtonRoleGuideline extends AccessibilityGuideline {
+  const ButtonRoleGuideline();
+
+  @override
+  String get description => 'Tappable nodes must declare a role (button/link/textField/…)';
+
+  @override
+  FutureOr<Evaluation> evaluate(WidgetTester tester) {
+    Evaluation result = const Evaluation.pass();
+    for (final RenderView view in tester.binding.renderViews) {
+      final SemanticsNode? root = view.owner?.semanticsOwner?.rootSemanticsNode;
+      if (root != null) {
+        result += _walk(root);
+      }
+    }
+    return result;
+  }
+
+  Evaluation _walk(SemanticsNode node) {
+    Evaluation result = const Evaluation.pass();
+    final SemanticsData data = node.getSemanticsData();
+    final bool tappable = data.hasAction(SemanticsAction.tap) ||
+        data.hasAction(SemanticsAction.longPress);
+    final flags = data.flagsCollection;
+    // Verified against the Flutter 3.44.2 SDK: role flags live on flagsCollection as
+    // bools, while checked/toggled/selected are Tristate (none = not applicable), and
+    // isMergedIntoParent is on the node, not on the flags.
+    final bool hasRole = flags.isButton ||
+        flags.isLink ||
+        flags.isTextField ||
+        flags.isSlider ||
+        flags.isKeyboardKey ||
+        flags.isInMutuallyExclusiveGroup ||
+        flags.isToggled != Tristate.none ||
+        flags.isSelected != Tristate.none;
+    if (tappable && !node.isMergedIntoParent && !flags.isHidden && !hasRole) {
+      result += Evaluation.fail(
+        '$node: tappable but declares no role. Wrap it in '
+        'Semantics(button: true, label: …) or use a real button widget.\n',
+      );
+    }
+    node.visitChildren((SemanticsNode child) {
+      result += _walk(child);
+      return true;
+    });
+    return result;
+  }
+}
+
+/// Fails when an accessible name carries no letters/digits — `'<'`, `'×'`, `'•••'`,
+/// `'…'`. The built-in label guideline accepts any non-empty string, so these pass
+/// there and then get read out as "less than", "multiplication sign", …
+///
+/// Whether a label is *understandable* is still a human judgement; this only rules
+/// out the labels that provably are not words.
+class MeaningfulLabelGuideline extends AccessibilityGuideline {
+  const MeaningfulLabelGuideline();
+
+  // Letters (incl. accented), digits, kana, CJK, Hangul. U+00D7 (×) and U+00F7 (÷)
+  // are deliberately excluded: they sit inside the Latin-1 letter block but are the
+  // most common "close" glyphs.
+  static final RegExp _wordish = RegExp(
+    r'[0-9A-Za-z'
+    r'À-ÖØ-öø-ɏ'
+    r'Ѐ-ӿ぀-ゟ゠-ヿ一-鿿가-힯]',
+  );
+
+  @override
+  String get description => 'Accessible names must contain words, not only symbols';
+
+  @override
+  FutureOr<Evaluation> evaluate(WidgetTester tester) {
+    Evaluation result = const Evaluation.pass();
+    for (final RenderView view in tester.binding.renderViews) {
+      final SemanticsNode? root = view.owner?.semanticsOwner?.rootSemanticsNode;
+      if (root != null) {
+        result += _walk(root);
+      }
+    }
+    return result;
+  }
+
+  Evaluation _walk(SemanticsNode node) {
+    Evaluation result = const Evaluation.pass();
+    final SemanticsData data = node.getSemanticsData();
+    final flags = data.flagsCollection;
+    final String name = data.label.isNotEmpty ? data.label : data.tooltip;
+    final bool interactive = data.hasAction(SemanticsAction.tap) ||
+        data.hasAction(SemanticsAction.longPress);
+    if (interactive &&
+        !node.isMergedIntoParent &&
+        !flags.isHidden &&
+        name.trim().isNotEmpty &&
+        !_wordish.hasMatch(name)) {
+      result += Evaluation.fail(
+        '$node: accessible name "$name" is symbols only — it will be read as a '
+        'symbol name. Give it a word ("戻る"/"閉じる") and hide the glyph with '
+        'ExcludeSemantics.\n',
+      );
+    }
+    node.visitChildren((SemanticsNode child) {
+      result += _walk(child);
+      return true;
+    });
+    return result;
+  }
+}

--- a/examples/a11y/web/eslint-a11y.config.md
+++ b/examples/a11y/web/eslint-a11y.config.md
@@ -1,0 +1,153 @@
+# Web (Next.js / React) — a11y を既定にする配線
+
+3 層に分ける。①lint（書いた瞬間）②axe(実行時 DOM)③reflow/拡大。どれも無料 OSS で、
+どれも exit code で判定できる。
+
+---
+
+## 1. eslint-plugin-jsx-a11y を「明示的に」有効化する
+
+`eslint-config-next`（`next/core-web-vitals`）は jsx-a11y を**同梱しているが有効化するのは
+一部のルールだけ**。「next lint を使っている」は「a11y を lint している」ではない。
+kit の静的ゲートはこの状態を `A11Y-PROJ-WEB-LINT-SUBSET`（warn）として区別して報告する。
+
+```js
+// eslint.config.mjs (flat config)
+import next from "eslint-config-next/core-web-vitals";
+import jsxA11y from "eslint-plugin-jsx-a11y";
+
+export default [
+  ...next,
+  {
+    // ⚠️ `jsxA11y.flatConfigs.recommended` を spread してはいけない。
+    // eslint-config-next が既に jsx-a11y プラグインを登録しているため、ESLint 9 は
+    // `Cannot redefine plugin "jsx-a11y"` で **起動しなくなる**（= lint が 1 行も走らない）。
+    // プラグイン定義ではなく **rules だけ** を上乗せする。
+    rules: {
+      ...jsxA11y.flatConfigs.recommended.rules,
+      // 既定では warn のものを error に上げる（warn は放置され exit 0 のまま）
+      "jsx-a11y/alt-text": "error",
+      "jsx-a11y/anchor-is-valid": "error",
+      "jsx-a11y/click-events-have-key-events": "error",
+      "jsx-a11y/no-static-element-interactions": "error",
+      "jsx-a11y/interactive-supports-focus": "error",
+      "jsx-a11y/label-has-associated-control": "error",
+      "jsx-a11y/aria-props": "error",
+      "jsx-a11y/role-has-required-aria-props": "error",
+    },
+  },
+];
+```
+
+```jsonc
+// package.json — warn で exit 0 になるのを防ぐ
+{
+  "scripts": {
+    "lint": "eslint . --max-warnings 0"
+  }
+}
+```
+
+> **Next.js 16 以降は `next build` が lint を実行しない**。CI に独立した `eslint` ステップが
+> 必要（無いと「lint が緑」ではなく「lint が走っていない」になる）。
+
+### lint 設定そのものの生存確認（fixture 方式）
+
+設定ミスや ignore パターンで**全ファイルが未検査になっても lint は緑になる**。
+kit の hook テストと同じ block/pass 両ケースで設定自体を検査する。
+
+```bash
+# tests/a11y-fixtures/bad.tsx  → exit 1 になること
+# tests/a11y-fixtures/good.tsx → exit 0 になること
+npx eslint tests/a11y-fixtures/bad.tsx  && { echo "GATE DEAD: bad fixture passed"; exit 1; }
+npx eslint tests/a11y-fixtures/good.tsx || { echo "GATE NOISY: good fixture failed"; exit 1; }
+```
+
+```tsx
+// tests/a11y-fixtures/bad.tsx — 既知違反（検出されなければ設定が死んでいる）
+export const Bad = () => (
+  <div>
+    <div onClick={() => {}}>保存</div>
+    <img src="/x.png" />
+    <a>リンク</a>
+  </div>
+);
+```
+
+---
+
+## 2. axe-core を実行時 DOM に当てる（violations だけでなく incomplete も出す）
+
+```ts
+// e2e/a11y.spec.ts — @axe-core/playwright（無料 OSS）
+import { test, expect } from "@playwright/test";
+import AxeBuilder from "@axe-core/playwright";
+
+for (const colorScheme of ["light", "dark"] as const) {
+  test(`no a11y violations (${colorScheme})`, async ({ page }) => {
+    await page.emulateMedia({ colorScheme });
+    await page.goto("/");
+    const results = await new AxeBuilder({ page })
+      .withTags(["wcag2a", "wcag2aa", "wcag21a", "wcag21aa", "wcag22aa"])
+      .analyze();
+
+    // incomplete は「判定できなかった」＝人が見るキュー。捨てると静かなゼロになる。
+    console.log(`axe: ${results.violations.length} violations / ${results.incomplete.length} incomplete`);
+    expect(results.violations).toEqual([]);
+  });
+}
+```
+
+- **ダークモードは別テーマとして回す**。コントラストは片側だけ落ちるのが典型
+- `new AxeBuilder({ page })` は `browser.newPage()` のページで例外になる。`browser.newContext()`
+  から作ったページを使う
+- **`target-size`（SC 2.5.8）は axe の既定で無効**。明示的に有効化する:
+  `.options({ rules: { "target-size": { enabled: true } } })`
+- axe が自動検出できるのは WCAG 違反の一部（Deque 自身の調査で issue 件数ベース約 57%:
+  https://www.deque.com/blog/automated-testing-study-identifies-57-percent-of-digital-accessibility-issues/ ）
+- **Lighthouse の accessibility スコアを a11y ゲートにしない**。Lighthouse は accessibility を
+  「自動監査 + manual 監査」で構成し、**manual 側はスコアに一切影響しない**。その manual 項目が
+  `custom-controls-labels` / `custom-controls-roles` / `focusable-controls` / `logical-tab-order`
+  ＝まさに「自作ボタンに role が無い」系なので、**スコア 100 と「読み上げで操作不能」は両立する**
+- `pa11y` も使わない（既定エンジン HTML_CodeSniffer が WCAG 2.2 未対応で 2.4.11 / 2.5.8 が構造的に未検査）
+- **アイコンのみボタンと記号ラベル（`×` `<`）は lint も axe も検出しない**（axe は「discernible text あり」
+  として合格させる）。ここは kit の静的ゲート（`A11Y-WEB-CONTROL-NAME` / `A11Y-WEB-SYMBOL-LABEL`）が担う
+
+---
+
+## 3. 文字 200% と 320px reflow（SC 1.4.4 / 1.4.10）
+
+```ts
+test("reflow at 320px and text at 200%", async ({ page }) => {
+  await page.setViewportSize({ width: 320, height: 256 });
+  await page.goto("/");
+  const overflowsAt320 = await page.evaluate(
+    () => document.documentElement.scrollWidth > document.documentElement.clientWidth + 1,
+  );
+  expect(overflowsAt320, "320px で横スクロールが発生している").toBe(false);
+
+  await page.addStyleTag({ content: "html { font-size: 200% !important; }" });
+  const overflowsAt200 = await page.evaluate(
+    () => document.documentElement.scrollWidth > document.documentElement.clientWidth + 1,
+  );
+  expect(overflowsAt200, "文字 200% で横スクロールが発生している").toBe(false);
+});
+```
+
+意図的な横スクロール領域（データテーブル・地図・カルーセル）は SC 1.4.10 の正規の例外。
+`data-a11y-allow-overflow` のような opt-out 属性で明示し、**opt-out の件数をログに出す**
+（黙って除外すると「対応済み」に見えてしまう）。
+
+---
+
+## 4. CI
+
+```yaml
+- run: pnpm lint                    # jsx-a11y（error 昇格 + --max-warnings 0）
+- run: pnpm test:a11y-fixtures      # lint 設定自体の生存確認
+- run: pnpm exec playwright test e2e/a11y.spec.ts   # axe + reflow
+- run: python3 scripts/a11y-static-check.py --root . --baseline .a11y-baseline.json
+```
+
+最後の 1 行が kit の静的ゲート。lint より前の層（`.php` テンプレートや Flutter も同じ 1 コマンドで
+見る）を担い、`eslint` が見ない拡張子を埋める。

--- a/examples/ci/a11y-gate-pattern.md
+++ b/examples/ci/a11y-gate-pattern.md
@@ -1,0 +1,92 @@
+# CI pattern — the a11y gate as a ratchet
+
+The gate is useful in CI only if it can be adopted on a repo that already has
+violations. Blocking on "zero findings" on day one means the gate gets disabled on
+day two. So the CI shape is a **ratchet**: the known set is frozen in a committed
+baseline, new violations fail, and the baseline may only shrink.
+
+> Wiring a required status check / branch protection is a **deliberate, higher-risk
+> change**. Add the job first, watch it for a week, and only then make it required —
+> by hand. The gate never installs itself (see the boundary in
+> [`skills/a11y-static-gate/`](../../skills/a11y-static-gate/)).
+
+## 1. Freeze the current state (once, in a PR)
+
+```bash
+python3 scripts/a11y-static-check.py --root . \
+    --baseline .a11y-baseline.json --update-baseline
+git add .a11y-baseline.json
+```
+
+Commit the baseline **with the finding counts in the PR body** so the starting debt is
+on the record. A baseline created from an empty scan is refused (exit 3) — an empty
+scan is not a clean repo.
+
+## 2. Fail only on new violations
+
+```yaml
+# .github/workflows/a11y.yml
+name: a11y
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  a11y-static:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.x"
+      # The gate is stdlib-only python3: no npm install, no pub get, ~1s on a mid-size repo.
+      - name: a11y static gate (ratchet)
+        run: |
+          python3 scripts/a11y-static-check.py \
+            --root . --baseline .a11y-baseline.json
+```
+
+Exit codes the job relies on: `0` no new findings / `1` new findings / `2` usage or
+missing baseline / `3` **UNKNOWN — zero files scanned** (a wrong path, not a clean
+repo). Do not add `|| true`; that converts the gate into a decoration.
+
+## 3. Keep the runtime tests separate
+
+The static gate answers one question: *does every interactive element have a name, a
+role and a state?* It cannot see layout overflow at large text sizes, focus order, or
+whether a screen reader can actually complete a task. Those belong to the stack's own
+test job:
+
+```yaml
+  a11y-runtime:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      # Flutter: the framework's own guideline matchers + a largest-Dynamic-Type pass
+      # (template: examples/a11y/flutter/a11y_smoke_test.dart)
+      - run: flutter test test/a11y_smoke_test.dart
+      # Web: jsx-a11y runs inside `next lint`; axe-core runs against the rendered DOM
+      # (setup: examples/a11y/web/eslint-a11y.config.md)
+      - run: pnpm lint && pnpm test:a11y
+```
+
+## 4. Shrink the baseline, never grow it
+
+```bash
+# after fixing violations — prunes the fixed entries
+python3 scripts/a11y-static-check.py --root . \
+    --baseline .a11y-baseline.json --update-baseline
+```
+
+`--update-baseline` **refuses** to write a baseline with more errors than the previous
+one. Growth requires `--allow-baseline-growth`, which exists so that the exception is
+visible in the diff and has to be justified in the PR — the same discipline as
+[`coverage-floor-lock`](../../skills/coverage-floor-lock/), where a lowered floor is
+itself the finding.
+
+A useful monthly metric: `counts.error` in the baseline. It should only ever go down.

--- a/examples/project-standards-template/SKILL.md
+++ b/examples/project-standards-template/SKILL.md
@@ -73,6 +73,13 @@ e2e/                # E2E テスト
 - <例: ユーザー個人情報はサーバ送信前にマスキング>
 - <例: 第三者 AI サービス利用箇所は consent modal 必須>
 
+### アクセシビリティ（このプロジェクトの具体値）
+- <例: 操作要素は必ず共通 AppButton 経由。生の GestureDetector / div onClick は禁止>
+- <例: a11y ゲートの baseline は .a11y-baseline.json（件数は減る方向のみ）>
+- <例: 文字拡大クランプは maxScaleFactor 2.0（root 1 箇所）>
+- <例: 対応 AT = iOS VoiceOver / Android TalkBack。リリース前に主要導線 1 本を音声のみで通す>
+- <例: 除外して良い領域とその理由（デザイン検証用モック等）>
+
 ### テスト
 - <例: スナップショットテストは UI 変更時に必ず更新>
 - <例: E2E は auth flow 全体を 1 ケース必ず通す>
@@ -100,6 +107,7 @@ e2e/                # E2E テスト
 ## 8. dev-reviewer 向けメモ
 
 このプロジェクトでよくある指摘パターン:
+- <例: 新しい操作要素に accessible name / role を付け忘れる>
 - <例: 外部 API 呼出時の権限 request 漏れ>
 - <例: DB 認可ポリシーが schema 追加に追従していない>
 - <例: i18n 文字列を直接埋め込み — l10n 経由で>

--- a/scripts/a11y-static-check.py
+++ b/scripts/a11y-static-check.py
@@ -1,0 +1,1892 @@
+#!/usr/bin/env python3
+# =============================================================
+# a11y-static-check.py — accessibility static gate (detection only)
+#
+# Goal: fail a build when a UI change ships an interactive element that a screen
+# reader cannot use. The rule set is the "accessible name / role / state" triad
+# (WCAG 2.2 SC 4.1.2) applied to the three stacks this kit targets:
+#
+#   Flutter/Dart  (.dart)                 — Semantics / tooltip / semanticLabel
+#   React/Next.js (.tsx .jsx)             — ARIA + semantic HTML
+#   WordPress/PHP (.php .html .twig)      — semantic HTML
+#
+# It parses structure (a paren/tag stack with strings + comments masked), not
+# single lines, so "is this tappable thing wrapped by a labelled ancestor?" is
+# answered by the actual ancestor chain — the question a line-window grep gets
+# wrong in both directions.
+#
+# Non-goals (safety constraints):
+#   - DETECTION ONLY. Never edits code, never adds a Semantics widget, never
+#     rewrites a baseline unless --update-baseline is passed explicitly.
+#   - Never installs itself into CI. Wiring this as a required status check is a
+#     deliberate, higher-risk change a human makes on purpose.
+#   - No network, no gh/aws. Local file reads only.
+#   - Static analysis cannot prove accessibility. Passing this gate means "no
+#     *statically detectable* naming/role defect" — it never means "accessible".
+#     Screen-reader traversal and large-text layout still need the runtime tests
+#     and the device pass described in skills/a11y-standards/SKILL.md.
+#
+# Usage:
+#   python3 scripts/a11y-static-check.py --root <dir> [options]
+#     --root <dir>              tree to scan (required)
+#     --baseline <file>         known-violation snapshot (ratchet mode: only NEW findings fail)
+#     --update-baseline         rewrite the baseline from the current scan (refuses to grow it)
+#     --allow-baseline-growth   permit a baseline with MORE errors than before (must be justified)
+#     --strict                  warnings fail too (default: warnings are reported, not fatal)
+#     --format text|json        output format (default text)
+#     --exclude <substr>        extra path substring to skip (repeatable)
+#     --rules <ID,ID,...>       only run these rule ids
+#     --self-test               deterministic hermetic self-check
+#
+# Exit codes:
+#   0 = no NEW error-severity findings (with --strict: no new warnings either)
+#   1 = new violations found
+#   2 = usage / baseline read error (a missing baseline is an error, never a pass)
+#   3 = UNKNOWN — zero scannable files. An empty scan is NOT "zero violations";
+#       it usually means a wrong --root or an over-broad --exclude.
+#
+# Design notes:
+#   - stdlib only (python3). No jq, no node, no pub.
+#   - Deterministic: findings are sorted; the fingerprint used by the ratchet is
+#     content-based (rule + file + normalized snippet + ordinal), so unrelated
+#     edits above a finding do not churn the baseline.
+#   - Suppression needs a reason: `a11y-ignore: <why>` on the finding line or the
+#     line above. A bare `a11y-ignore` does not suppress (it is reported).
+# =============================================================
+
+import argparse
+import hashlib
+import json
+import os
+import re
+import sys
+
+SCHEMA_VERSION = 1
+
+ERROR = "error"
+WARN = "warn"
+
+# ---------------------------------------------------------------------------
+# File selection
+# ---------------------------------------------------------------------------
+
+DART_EXT = (".dart",)
+WEB_EXT = (".tsx", ".jsx")
+MARKUP_EXT = (".php", ".html", ".htm", ".twig")
+
+SCAN_EXT = DART_EXT + WEB_EXT + MARKUP_EXT
+
+# Directories/paths never scanned: vendored, generated, or test code. Test code is
+# excluded because fixtures deliberately build bare widgets; enforcing product
+# a11y rules there produces noise, not safety.
+DEFAULT_EXCLUDES = [
+    "/.git/",
+    "/node_modules/",
+    "/vendor/",
+    "/build/",
+    "/.next/",
+    "/.dart_tool/",
+    "/dist/",
+    "/coverage/",
+    "/ios/Pods/",
+    "/test/",
+    "/tests/",
+    "/spec/",
+    "/__tests__/",
+    "/integration_test/",
+    "/e2e/",
+    "/.storybook/",
+    "/playwright-report/",
+    "/storybook-static/",
+    "/.output/",
+    ".g.dart",
+    ".freezed.dart",
+    ".gr.dart",
+    ".mocks.dart",
+    ".config.dart",
+    ".test.tsx",
+    ".test.jsx",
+    ".spec.tsx",
+    ".spec.jsx",
+    ".stories.tsx",
+    ".stories.jsx",
+    ".min.js",
+]
+
+IGNORE_RE = re.compile(r"a11y-ignore\s*:\s*(\S.*)$")
+IGNORE_BARE_RE = re.compile(r"a11y-ignore(?!\s*:)")
+
+
+def iter_files(root, excludes):
+    """Every scannable file under root, as (relpath, fullpath), sorted."""
+    out = []
+    for dirpath, dirnames, filenames in os.walk(root):
+        dirnames[:] = [d for d in dirnames if d not in (".git", "node_modules", ".dart_tool")]
+        for fn in sorted(filenames):
+            if not fn.endswith(SCAN_EXT):
+                continue
+            full = os.path.join(dirpath, fn)
+            rel = os.path.relpath(full, root).replace(os.sep, "/")
+            probe = "/" + rel
+            if any(ex and ex in probe for ex in excludes):
+                continue
+            out.append((rel, full))
+    out.sort()
+    return out
+
+
+def read_text(full):
+    try:
+        with open(full, "r", encoding="utf-8", errors="replace") as fh:
+            return fh.read()
+    except OSError:
+        return None
+
+
+# ---------------------------------------------------------------------------
+# Shared helpers: labels, symbols, offsets
+# ---------------------------------------------------------------------------
+
+# A label is "symbol-only" when it carries no letter, digit or CJK character —
+# e.g. "<" (a screen reader says "less than"), "×", "•••", "+", "❯".
+# NOTE: the Latin-1 supplement range deliberately skips U+00D7 (multiplication sign)
+# and U+00F7 (division sign): they sit between accented letters but are math symbols,
+# and U+00D7 is the most common "close button" glyph. Treating it as a letter would
+# silently pass exactly the case this rule exists to catch.
+WORDISH_RE = re.compile(
+    r"[0-9A-Za-z"
+    r"\u00c0-\u00d6\u00d8-\u00f6\u00f8-\u024f"
+    r"\u0400-\u04ff\u3040-\u309f\u30a0-\u30ff\u3400-\u4dbf\u4e00-\u9fff\uac00-\ud7af]"
+)
+
+UNICODE_ESCAPE_RE = re.compile(r"\\u\{([0-9a-fA-F]+)\}|\\u([0-9a-fA-F]{4})|\\x([0-9a-fA-F]{2})")
+
+
+def decode_escapes(s):
+    """Decode \\uXXXX / \\u{...} / \\xXX so '\\u2022\\u2022\\u2022' is seen as '•••'."""
+
+    def sub(m):
+        hexpart = m.group(1) or m.group(2) or m.group(3)
+        try:
+            return chr(int(hexpart, 16))
+        except (ValueError, OverflowError):
+            return ""
+
+    return UNICODE_ESCAPE_RE.sub(sub, s)
+
+
+def is_symbol_only(label):
+    return not WORDISH_RE.search(decode_escapes(label))
+
+
+def line_of(text, offset):
+    return text.count("\n", 0, offset) + 1
+
+
+def normalize_snippet(s):
+    """Whitespace-insensitive snippet used for the content-based fingerprint."""
+    return re.sub(r"\s+", " ", s).strip()[:240]
+
+
+def mask_regions(text, regions, keep_newlines=True):
+    """Replace each (start, end) region with spaces, preserving offsets (and line
+    numbers, when keep_newlines)."""
+    buf = list(text)
+    for start, end in regions:
+        for i in range(start, min(end, len(buf))):
+            if keep_newlines and buf[i] == "\n":
+                continue
+            buf[i] = " "
+    return "".join(buf)
+
+
+# ---------------------------------------------------------------------------
+# Dart / Flutter
+# ---------------------------------------------------------------------------
+
+def dart_masked(text):
+    """Mask comments and string *contents* (quotes kept) so a paren scan is safe."""
+    regions = []
+    i = 0
+    n = len(text)
+    while i < n:
+        c = text[i]
+        nxt = text[i + 1] if i + 1 < n else ""
+        if c == "/" and nxt == "/":
+            j = text.find("\n", i)
+            j = n if j < 0 else j
+            regions.append((i, j))
+            i = j
+            continue
+        if c == "/" and nxt == "*":
+            j = text.find("*/", i + 2)
+            j = n if j < 0 else j + 2
+            regions.append((i, j))
+            i = j
+            continue
+        if c in "'\"":
+            triple = text[i:i + 3]
+            if triple in ("'''", '"""'):
+                quote = triple
+                j = text.find(quote, i + 3)
+                j = n if j < 0 else j + 3
+                regions.append((i + 3, j - 3 if j > i + 3 else j))
+                i = j
+                continue
+            quote = c
+            j = i + 1
+            while j < n:
+                if text[j] == "\\":
+                    j += 2
+                    continue
+                if text[j] == quote:
+                    break
+                if text[j] == "\n":  # unterminated single-line string: stop here
+                    break
+                j += 1
+            regions.append((i + 1, j))
+            i = min(j + 1, n)
+            continue
+        i += 1
+    return mask_regions(text, regions)
+
+
+IDENT_BEFORE_PAREN_RE = re.compile(r"([A-Za-z_$][A-Za-z0-9_$]*(?:\.[A-Za-z_$][A-Za-z0-9_$]*)*)\s*$")
+
+
+class Node(object):
+    __slots__ = ("name", "start", "open", "end", "line", "parent", "children")
+
+    def __init__(self, name, start, open_pos, line, parent):
+        self.name = name
+        self.start = start          # start of the identifier
+        self.open = open_pos        # position of "("
+        self.end = -1               # position just after the matching ")"
+        self.line = line
+        self.parent = parent
+        self.children = []
+
+
+def parse_call_tree(text, masked):
+    """Build the constructor-call tree of a Dart file.
+
+    Every "(" is tracked so paren matching stays correct, but only capitalized
+    identifiers (widget/class constructors) become tree nodes, which is what the
+    ancestor questions are about.
+    """
+    nodes = []
+    stack = []          # every open paren: (node_or_None,)
+    named_stack = []    # only named nodes
+    i = 0
+    n = len(masked)
+    while i < n:
+        c = masked[i]
+        if c == "(":
+            m = IDENT_BEFORE_PAREN_RE.search(masked, 0, i)
+            name = m.group(1) if m else None
+            node = None
+            if name and name.split(".")[0][:1].isupper():
+                parent = named_stack[-1] if named_stack else None
+                node = Node(name, m.start(1), i, line_of(text, m.start(1)), parent)
+                if parent is not None:
+                    parent.children.append(node)
+                nodes.append(node)
+                named_stack.append(node)
+            stack.append(node)
+        elif c == ")":
+            if stack:
+                node = stack.pop()
+                if node is not None:
+                    node.end = i + 1
+                    if named_stack and named_stack[-1] is node:
+                        named_stack.pop()
+        i += 1
+    # Unterminated nodes (truncated file) end at EOF so slicing stays safe.
+    for nd in nodes:
+        if nd.end < 0:
+            nd.end = n
+    return nodes
+
+
+def own_text(text, node):
+    """The node's own argument text, with nested named-node spans removed, so
+    `onTap:` found here belongs to THIS widget and not to a descendant."""
+    pieces = []
+    cursor = node.open
+    for child in node.children:
+        if child.start < cursor:
+            continue
+        pieces.append(text[cursor:child.start])
+        cursor = max(cursor, child.end)
+    pieces.append(text[cursor:node.end])
+    return "".join(pieces)
+
+
+DART_STRING_RE = re.compile(r"'''(.*?)'''|\"\"\"(.*?)\"\"\"|'((?:\\.|[^'\\\n])*)'|\"((?:\\.|[^\"\\\n])*)\"", re.S)
+
+
+def first_string_literal(s):
+    m = DART_STRING_RE.search(s)
+    if not m:
+        return None
+    for g in m.groups():
+        if g is not None:
+            return g
+    return ""
+
+
+def _find_top_level_key(own, key):
+    """Position just after `key:` when it appears at the node's OWN argument depth.
+
+    Depth matters: `Column(children: [ ... onTap: () => x ... ])` must not make the
+    Column itself look tappable just because a closure inside its child list has a
+    tap handler. `own` starts at the node's own "(", and that paren establishes the
+    argument level, so scanning starts just inside it.
+    """
+    pat = re.compile(r"(?<![A-Za-z0-9_])" + re.escape(key) + r"\s*:")
+    depth = 0
+    i = 1 if own[:1] == "(" else 0
+    n = len(own)
+    while i < n:
+        c = own[i]
+        if depth == 0:
+            m = pat.match(own, i)
+            if m:
+                return m.end()
+        if c in "([{":
+            depth += 1
+        elif c in ")]}":
+            if depth == 0:
+                break  # this closes the node's own argument list
+            depth -= 1
+        i += 1
+    return None
+
+
+def arg_value(own, key):
+    """Raw text of `key:` up to the next top-level comma (approximate but enough
+    to tell null / '' / an expression apart)."""
+    end = _find_top_level_key(own, key)
+    if end is None:
+        return None
+    i = end
+    depth = 0
+    out = []
+    while i < len(own):
+        ch = own[i]
+        if ch in "([{":
+            depth += 1
+        elif ch in ")]}":
+            if depth == 0:
+                break
+            depth -= 1
+        elif ch == "," and depth == 0:
+            break
+        out.append(ch)
+        i += 1
+    return "".join(out).strip()
+
+
+def has_nonempty_arg(own, key):
+    v = arg_value(own, key)
+    if v is None:
+        return False
+    if v in ("null", ""):
+        return False
+    lit = first_string_literal(v)
+    if lit is not None and lit.strip() == "" and v.strip().startswith(("'", '"')):
+        return False  # hintText: '' names nothing
+    return True
+
+
+# Custom tap wrappers: no intrinsic role — a screen reader announces the child,
+# never "button", unless Semantics(button: true) is added.
+DART_CUSTOM_TAP = {"GestureDetector", "InkWell", "InkResponse", "RawGestureDetector"}
+
+# Real button/interactive widgets: role comes from the framework, name does not.
+DART_NATIVE_INTERACTIVE = {
+    "IconButton", "TextButton", "ElevatedButton", "OutlinedButton", "FilledButton",
+    "CupertinoButton", "FloatingActionButton", "PopupMenuButton", "ListTile",
+    "CheckboxListTile", "SwitchListTile", "RadioListTile", "MenuItemButton",
+    "SegmentedButton", "DropdownButton", "Chip", "ActionChip", "InputChip",
+    "CloseButton", "BackButton",
+}
+
+DART_TAP_ARGS = ("onTap", "onPressed", "onLongPress", "onDoubleTap", "onTapDown", "onSelected")
+
+# Layout/scroll containers: they take builder callbacks that legitimately contain tap
+# handlers deeper down, so they must never be classified as the tappable element.
+DART_CONTAINER_NAMES = {
+    "Column", "Row", "Stack", "Padding", "Center", "Container", "SizedBox", "Expanded",
+    "Flexible", "Wrap", "ListView", "GridView", "PageView", "CustomScrollView",
+    "SingleChildScrollView", "Scaffold", "MaterialApp", "CupertinoApp", "Builder",
+    "AnimatedBuilder", "LayoutBuilder", "ValueListenableBuilder", "Consumer",
+}
+
+DART_FIELDS = {"TextField", "TextFormField", "CupertinoTextField", "CupertinoSearchTextField"}
+DART_TOGGLES = {"Switch", "CupertinoSwitch", "Checkbox", "Radio", "Slider", "SwitchListTile", "CheckboxListTile"}
+DART_IMAGES = {"Image", "Image.asset", "Image.network", "Image.file", "Image.memory", "FadeInImage"}
+
+# Widgets that give their child an accessible name.
+DART_NAMING_ANCESTORS = {"Semantics": ("label",), "Tooltip": ("message",), "MergeSemantics": ()}
+DART_LABEL_CARRIERS = {"ListTile", "CheckboxListTile", "SwitchListTile", "RadioListTile"}
+
+
+def dart_label_state(text, node):
+    """Resolve the accessible name/role/state situation for one node.
+
+    Returns (named, symbol_label, role_ok, excluded, enabled_declared) where
+    `symbol_label` is set only when the *effective* name is symbol-only. An
+    explicit Semantics/tooltip label wins over descendant text (that is the
+    precedence Flutter applies), so a symbol glyph deliberately hidden under
+    ExcludeSemantics next to a real label is not a finding.
+    """
+    explicit_label = None      # from Semantics(label:) / tooltip: / semanticLabel:
+    explicit_named = False     # an explicit name exists (possibly a non-literal expression)
+    text_label = None          # first literal from a descendant Text()
+    text_named = False
+    role_ok = node.name in DART_NATIVE_INTERACTIVE
+    excluded = False
+    enabled_declared = False
+
+    own = own_text(text, node)
+
+    def note_explicit(raw):
+        nonlocal explicit_label, explicit_named
+        explicit_named = True
+        lit = first_string_literal(raw or "")
+        if explicit_label is None and lit is not None and lit.strip():
+            explicit_label = lit
+
+    # self args
+    for key in ("tooltip", "semanticLabel"):
+        if has_nonempty_arg(own, key):
+            note_explicit(arg_value(own, key))
+    if node.name in DART_LABEL_CARRIERS | {"Semantics"} and has_nonempty_arg(own, "label"):
+        note_explicit(arg_value(own, "label"))
+    if node.name in DART_LABEL_CARRIERS and has_nonempty_arg(own, "title"):
+        explicit_named = True
+
+    # ancestors
+    cur = node.parent
+    while cur is not None:
+        if cur.name == "ExcludeSemantics":
+            excluded = True
+        a_own = own_text(text, cur)
+        if cur.name == "Semantics":
+            if has_nonempty_arg(a_own, "label"):
+                note_explicit(arg_value(a_own, "label"))
+            if re.search(r"(?<![A-Za-z0-9_])button\s*:\s*true", a_own):
+                role_ok = True
+            if re.search(r"(?<![A-Za-z0-9_])enabled\s*:", a_own):
+                enabled_declared = True
+        elif cur.name == "Tooltip" and has_nonempty_arg(a_own, "message"):
+            note_explicit(arg_value(a_own, "message"))
+        elif cur.name in DART_LABEL_CARRIERS and (
+            has_nonempty_arg(a_own, "title") or has_nonempty_arg(a_own, "label")
+        ):
+            explicit_named = True
+            role_ok = True
+        cur = cur.parent
+
+    # descendants: a Text/Icon child names the element (Flutter derives the
+    # semantic label from text automatically). Subtrees explicitly hidden with
+    # ExcludeSemantics are skipped — they contribute no name.
+    def walk(nd):
+        for ch in nd.children:
+            if ch.name == "ExcludeSemantics":
+                continue
+            yield ch
+            for sub in walk(ch):
+                yield sub
+
+    for d in walk(node):
+        if d.name in ("Text", "SelectableText", "RichText"):
+            lit = first_string_literal(own_text(text, d))
+            if lit is None:
+                text_named = True  # Text(variable) — dynamic but a name exists
+            elif lit.strip() == "":
+                continue
+            elif is_symbol_only(lit):
+                text_named = True
+                if text_label is None:
+                    text_label = lit
+            else:
+                text_named = True
+                text_label = None
+                break
+        elif d.name == "Icon" and has_nonempty_arg(own_text(text, d), "semanticLabel"):
+            note_explicit(arg_value(own_text(text, d), "semanticLabel"))
+        elif d.name == "Semantics" and has_nonempty_arg(own_text(text, d), "label"):
+            note_explicit(arg_value(own_text(text, d), "label"))
+
+    named = explicit_named or text_named
+    # Effective name: an explicit label wins; only fall back to descendant text.
+    if explicit_named:
+        symbol_label = explicit_label if (explicit_label and is_symbol_only(explicit_label)) else None
+    else:
+        symbol_label = text_label
+    return named, symbol_label, role_ok, excluded, enabled_declared
+
+
+def scan_dart(rel, text, emit):
+    masked = dart_masked(text)
+    nodes = parse_call_tree(text, masked)
+    interactive_seen = 0
+    unknown_ctors = {}
+
+    for node in nodes:
+        own = own_text(text, node)
+        # Named constructors (`TextButton.icon`, `FloatingActionButton.extended`,
+        # `ListView.builder`) must classify like their base widget, or every `.icon`
+        # variant looks like an unknown project widget.
+        base_name = node.name.split(".")[0]
+        is_custom = base_name in DART_CUSTOM_TAP
+        is_native = base_name in DART_NATIVE_INTERACTIVE
+        tap_arg = None
+        conditional_tap = False
+        for key in DART_TAP_ARGS:
+            v = arg_value(own, key)
+            if v is None:
+                continue
+            if v == "null":
+                continue
+            tap_arg = key
+            if "?" in v and ":" in v:
+                conditional_tap = True
+            break
+
+        if (is_custom or is_native) and tap_arg:
+            interactive_seen += 1
+            named, symbol_label, role_ok, excluded, enabled_declared = dart_label_state(text, node)
+            if excluded:
+                continue
+            snippet = normalize_snippet(text[node.start:min(node.end, node.start + 200)])
+            if not named:
+                emit(
+                    rule="A11Y-FLUTTER-NAME",
+                    severity=ERROR,
+                    file=rel,
+                    line=node.line,
+                    message="%s に %s があるが accessible name が無い（読み上げでは無名の要素になる）" % (node.name, tap_arg),
+                    fix="Semantics(button: true, label: '<操作の意味>', child: ...) で包む / IconButton なら tooltip: を付ける",
+                    snippet=snippet,
+                )
+            elif symbol_label:
+                emit(
+                    rule="A11Y-FLUTTER-SYMBOL-LABEL",
+                    severity=ERROR,
+                    file=rel,
+                    line=node.line,
+                    message="操作要素のラベルが記号のみ（%s）— 記号名で読み上げられる（例: '<' は「小なり」）"
+                            % repr(decode_escapes(symbol_label)),
+                    fix="Semantics(label: '戻る') 等の意味のあるラベルを付け、記号は excludeSemantics 側へ",
+                    snippet=snippet,
+                )
+            elif is_custom and not role_ok:
+                emit(
+                    rule="A11Y-FLUTTER-ROLE",
+                    severity=ERROR,
+                    file=rel,
+                    line=node.line,
+                    message="%s にラベルはあるが button role が無い（「ボタン」と読み上げられず操作可能だと伝わらない）" % node.name,
+                    fix="Semantics(button: true, child: ...) を付ける / 実ボタン Widget（TextButton 等）に置き換える",
+                    snippet=snippet,
+                )
+            if conditional_tap and not enabled_declared:
+                emit(
+                    rule="A11Y-FLUTTER-STATE",
+                    severity=WARN,
+                    file=rel,
+                    line=node.line,
+                    message="%s が %s で有効/無効を切り替えているが Semantics(enabled:) が無い（無効状態が読み上げられない）" % (node.name, tap_arg),
+                    fix="Semantics(button: true, enabled: <条件>, label: ...) で状態も公開する",
+                    snippet=snippet,
+                )
+
+        # The interactive-constructor lists above are hardcoded, so they drift as the
+        # framework and the project's own widgets evolve. Report tappables we could not
+        # classify instead of silently passing them: a filter nobody can see is worse
+        # than a finding nobody expected.
+        if (
+            tap_arg
+            and not is_custom
+            and not is_native
+            and base_name not in DART_CONTAINER_NAMES
+            and node.name[:1].isupper()
+        ):
+            # Aggregate per constructor: 39 identical lines about one shared wrapper is
+            # noise, "this wrapper is used 39 times and we cannot see inside it" is signal.
+            entry = unknown_ctors.setdefault(node.name, {"line": node.line, "count": 0, "arg": tap_arg})
+            entry["count"] += 1
+            entry["line"] = min(entry["line"], node.line)
+
+        if base_name in DART_FIELDS:
+            named, symbol_label, _role, excluded, _en = dart_label_state(text, node)
+            deco = None
+            for ch in node.children:
+                if ch.name in ("InputDecoration", "BoxDecoration"):
+                    deco = own_text(text, ch)
+                    break
+            labelled = (
+                has_nonempty_arg(own, "labelText")
+                or has_nonempty_arg(own, "placeholder")
+                or (deco is not None and (has_nonempty_arg(deco, "labelText") or has_nonempty_arg(deco, "hintText")))
+            )
+            if not excluded and not labelled and not named:
+                emit(
+                    rule="A11Y-FLUTTER-FIELD-NAME",
+                    severity=ERROR,
+                    file=rel,
+                    line=node.line,
+                    message="%s に accessible name が無い（無名の入力欄として読み上げられる）" % node.name,
+                    fix="InputDecoration(labelText: '<項目名>') / Semantics(textField: true, label: '<項目名>')",
+                    snippet=normalize_snippet(text[node.start:min(node.end, node.start + 200)]),
+                )
+
+        if base_name in DART_TOGGLES:
+            named, _sym, _role, excluded, _en = dart_label_state(text, node)
+            if not excluded and not named:
+                emit(
+                    rule="A11Y-FLUTTER-TOGGLE-NAME",
+                    severity=ERROR,
+                    file=rel,
+                    line=node.line,
+                    message="%s に accessible name が無い（何のスイッチか読み上げられない）" % node.name,
+                    fix="Semantics(label: '<対象>', child: ...) で包む / SwitchListTile(title: Text('<対象>')) を使う",
+                    snippet=normalize_snippet(text[node.start:min(node.end, node.start + 200)]),
+                )
+
+        # A global text-scale clamp below 200% turns "we support large text" into a
+        # violation of the very criterion it claims to satisfy (WCAG 1.4.4 asks for
+        # 200%), and it also disqualifies Apple's "Larger Text" declaration.
+        if node.name in ("MediaQuery.withClampedTextScaling",) or (
+            node.name == "TextScaler.clamp"
+        ):
+            raw_max = arg_value(own, "maxScaleFactor")
+            if raw_max:
+                m_num = re.search(r"([0-9]+(?:\.[0-9]+)?)", raw_max)
+                if m_num:
+                    try:
+                        if float(m_num.group(1)) < 2.0:
+                            emit(
+                                rule="A11Y-FLUTTER-SCALE-CLAMP",
+                                severity=ERROR,
+                                file=rel,
+                                line=node.line,
+                                message="文字拡大を %s 倍でクランプしている — 200%% までの拡大を要求する WCAG 1.4.4 に反し、"
+                                        "Apple の Larger Text 申告も満たせない" % m_num.group(1),
+                                fix="maxScaleFactor は 2.0 以上にする。溢れるなら固定高さを可変にする（クランプは緩和策で修正ではない）",
+                                snippet=normalize_snippet(text[node.start:min(node.end, node.start + 160)]),
+                            )
+                    except ValueError:
+                        pass
+
+        if base_name in DART_IMAGES or node.name in DART_IMAGES:
+            inside_interactive = False
+            cur = node.parent
+            while cur is not None:
+                if cur.name in DART_CUSTOM_TAP or cur.name in DART_NATIVE_INTERACTIVE:
+                    inside_interactive = True
+                    break
+                cur = cur.parent
+            excl = re.search(r"excludeFromSemantics\s*:\s*true", own) is not None
+            if not inside_interactive and not excl and not has_nonempty_arg(own, "semanticLabel"):
+                emit(
+                    rule="A11Y-FLUTTER-IMAGE-LABEL",
+                    severity=WARN,
+                    file=rel,
+                    line=node.line,
+                    message="%s に semanticLabel が無い（情報を持つ画像なら読み上げ不能・装飾なら明示が必要）" % node.name,
+                    fix="意味のある画像は semanticLabel: '<内容>' / 装飾は excludeFromSemantics: true",
+                    snippet=normalize_snippet(text[node.start:min(node.end, node.start + 160)]),
+                )
+
+    for ctor, info in sorted(unknown_ctors.items()):
+        emit(
+            rule="A11Y-FLUTTER-UNKNOWN-TAP-CTOR",
+            severity=WARN,
+            file=rel,
+            line=info["line"],
+            message="%s（%s を持つ・このファイルで %d 箇所）は既知の操作要素リストに無い — "
+                    "name/role を検査できていない" % (ctor, info["arg"], info["count"]),
+            fix="共通ボタン Widget ならその定義ファイル側で name/role を保証する（1 箇所直せば全呼出に効く）",
+            snippet="unknown-tap-ctor:%s" % ctor,
+        )
+
+    return {"interactive": interactive_seen}
+
+
+# ---------------------------------------------------------------------------
+# Markup (JSX/TSX + PHP/HTML)
+# ---------------------------------------------------------------------------
+
+TAG_RE = re.compile(r"<(/?)([A-Za-z][A-Za-z0-9_.:-]*)((?:[^<>\"'{}]|\"[^\"]*\"|'[^']*'|\{[^{}]*\})*)(/?)>", re.S)
+ATTR_RE = re.compile(r"([A-Za-z_:][-A-Za-z0-9_:.]*)\s*(?:=\s*(\"[^\"]*\"|'[^']*'|\{[^{}]*\}|[^\s>]+))?")
+
+WEB_NONINTERACTIVE = {"div", "span", "li", "td", "tr", "p", "section", "article", "header", "footer", "main", "nav", "figure", "label", "h1", "h2", "h3", "h4", "h5", "h6"}
+WEB_CLICK_ATTRS = ("onClick", "onclick", "onMouseDown", "onMouseUp", "onPointerDown")
+WEB_KEY_ATTRS = ("onKeyDown", "onKeyUp", "onKeyPress", "onkeydown")
+WEB_CONTROLS = {"button", "a", "summary"}
+WEB_FIELDS = {"input", "select", "textarea"}
+WEB_NAME_ATTRS = ("aria-label", "aria-labelledby", "title", "alt")
+
+
+def markup_masked(text, php=False):
+    """Mask comments (JS/JSX/HTML), template literals and, for PHP, the inside of
+    <?php ?> blocks — keeping offsets so line numbers stay true.
+
+    Template literals matter: docs pages embed JSX *as a code sample* inside
+    backticks. Scanning those produces findings about text that never renders,
+    which is the fastest way to make a gate look untrustworthy.
+    """
+    regions = []
+    for m in re.finditer(r"<!--.*?-->", text, re.S):
+        regions.append((m.start(), m.end()))
+    for m in re.finditer(r"/\*.*?\*/", text, re.S):
+        regions.append((m.start(), m.end()))
+    if not php:
+        for m in re.finditer(r"`(?:\\.|[^`\\])*`", text, re.S):
+            regions.append((m.start() + 1, m.end() - 1))
+    if php:
+        # Keep a marker so "there is dynamic output here" is still detectable:
+        # replace only the code body, not the delimiters.
+        for m in re.finditer(r"<\?(?:php|=)?(.*?)(?:\?>|$)", text, re.S):
+            if m.group(1):
+                regions.append((m.start(1), m.end(1)))
+    return mask_regions(text, regions)
+
+
+def parse_attrs(raw):
+    attrs = {}
+    for m in ATTR_RE.finditer(raw or ""):
+        key = m.group(1)
+        val = m.group(2)
+        if val is None:
+            attrs[key] = True
+            continue
+        if val[:1] in "\"'" and val[-1:] == val[:1]:
+            attrs[key] = val[1:-1]
+        else:
+            attrs[key] = val  # {expr} or bare
+    return attrs
+
+
+def attr_names(attrs, keys):
+    for k in keys:
+        if k in attrs:
+            v = attrs[k]
+            if v is True:
+                continue
+            if isinstance(v, str):
+                s = v.strip()
+                if s == "" or s in ("{''}", '{""}', "{}"):
+                    continue
+                if s.startswith("{") and s.endswith("}"):
+                    return True  # {t('save')} — dynamic name, assume real
+                return True
+    return False
+
+
+def scan_markup(rel, text, php, emit):
+    masked = markup_masked(text, php=php)
+    tags = []
+    for m in TAG_RE.finditer(masked):
+        closing = m.group(1) == "/"
+        name = m.group(2)
+        selfclose = m.group(4) == "/" or name.lower() in ("img", "input", "br", "hr", "source", "meta", "link")
+        tags.append({
+            "closing": closing,
+            "name": name,
+            "lname": name.lower(),
+            "raw": text[m.start(3):m.end(3)],
+            "start": m.start(),
+            "end": m.end(),
+            "selfclose": selfclose,
+            "line": line_of(text, m.start()),
+        })
+
+    # Pair open/close to know inner text
+    stack = []
+    interactive_seen = 0
+    for idx, t in enumerate(tags):
+        if t["closing"]:
+            for j in range(len(stack) - 1, -1, -1):
+                if stack[j]["lname"] == t["lname"]:
+                    stack[j]["inner_end"] = t["start"]
+                    del stack[j:]
+                    break
+            continue
+        t["inner_end"] = None
+        if not t["selfclose"]:
+            stack.append(t)
+
+    def inner_text(t):
+        if t.get("inner_end"):
+            return text[t["end"]:t["inner_end"]]
+        return ""
+
+    # <label> association, both forms the HTML spec allows:
+    #   explicit — <label for="x"> ... <input id="x">
+    #   implicit — <label>Campaign ID <input></label>  (no id needed, and valid)
+    # Missing the implicit form is a false positive on perfectly accessible code.
+    label_for_ids = set()
+    label_spans = []
+    for t in tags:
+        if t["closing"] or t["lname"] != "label":
+            continue
+        lattrs = parse_attrs(t["raw"])
+        for key in ("for", "htmlFor"):
+            v = lattrs.get(key)
+            if isinstance(v, str) and v.strip():
+                label_for_ids.add(v.strip().strip("{}\"'"))
+        if t.get("inner_end"):
+            body = text[t["end"]:t["inner_end"]]
+            named_label = bool(WORDISH_RE.search(re.sub(r"<[^>]*>", " ", body))) or ("{" in body) or ("<?" in body)
+            label_spans.append((t["end"], t["inner_end"], named_label))
+
+    def wrapped_by_named_label(pos):
+        return any(start <= pos <= end and named for start, end, named in label_spans)
+
+    for t in tags:
+        if t["closing"]:
+            continue
+        attrs = parse_attrs(t["raw"])
+        lname = t["lname"]
+        snippet = normalize_snippet(text[t["start"]:t["end"]])
+        prefix = "A11Y-MARKUP" if php else "A11Y-WEB"
+
+        # A zoom-locked viewport breaks WCAG 1.4.4 for everyone on the page at once,
+        # and it is one grep away from certainty — no ancestor reasoning needed.
+        if lname == "meta" and str(attrs.get("name", "")).strip().strip("\"'") == "viewport":
+            content = str(attrs.get("content", ""))
+            zoom_locked = re.search(r"user-scalable\s*=\s*(no|0)", content) is not None
+            max_scale = re.search(r"maximum-scale\s*=\s*([0-9.]+)", content)
+            if max_scale:
+                try:
+                    zoom_locked = zoom_locked or float(max_scale.group(1)) < 2.0
+                except ValueError:
+                    pass
+            if zoom_locked:
+                emit(
+                    rule=prefix + "-VIEWPORT-ZOOM",
+                    severity=ERROR,
+                    file=rel,
+                    line=t["line"],
+                    message="viewport が拡大を禁止している（user-scalable=no / maximum-scale<2）— 拡大が必要な利用者を全ページで排除する",
+                    fix='content="width=device-width, initial-scale=1" のみにする（拡大禁止を外す）',
+                    snippet=snippet,
+                )
+
+        # A positive tabindex rewrites the tab order globally; 0 / -1 are the only
+        # values that stay in document order.
+        tabindex_val = attrs.get("tabindex", attrs.get("tabIndex"))
+        if isinstance(tabindex_val, str):
+            # The sign must be part of the match: a bare [0-9]+ reads "-1" as 1.
+            m_ti = re.search(r"(-?[0-9]+)", tabindex_val)
+            if m_ti and int(m_ti.group(1)) > 0:
+                emit(
+                    rule=prefix + "-POSITIVE-TABINDEX",
+                    severity=ERROR,
+                    file=rel,
+                    line=t["line"],
+                    message="tabindex=%s（正の値）— タブ順が DOM 順から乖離し、以降の要素の順序が壊れる" % m_ti.group(1),
+                    fix="tabindex は 0（順序に含める）か -1（プログラム的にのみ focus）だけを使い、順序は DOM 側で表現する",
+                    snippet=snippet,
+                )
+
+        # img / next-Image alt
+        if lname in ("img", "image"):
+            if "alt" not in attrs:
+                emit(
+                    rule=prefix + "-IMG-ALT",
+                    severity=ERROR,
+                    file=rel,
+                    line=t["line"],
+                    message="<%s> に alt が無い（読み上げでファイル名が読まれる/無視される）" % t["name"],
+                    fix='意味のある画像は alt="内容の説明"、装飾は alt=""（空文字を明示）',
+                    snippet=snippet,
+                )
+            continue
+
+        # div/span with a click handler = a button without a role
+        if lname in WEB_NONINTERACTIVE and any(k in attrs for k in WEB_CLICK_ATTRS):
+            missing = []
+            if "role" not in attrs:
+                missing.append("role")
+            if "tabIndex" not in attrs and "tabindex" not in attrs:
+                missing.append("tabIndex")
+            if not any(k in attrs for k in WEB_KEY_ATTRS):
+                missing.append("キーボードハンドラ")
+            interactive_seen += 1
+            if missing:
+                emit(
+                    rule=prefix + "-INTERACTIVE-DIV",
+                    severity=ERROR,
+                    file=rel,
+                    line=t["line"],
+                    message="<%s> にクリックハンドラがあるが %s が無い（キーボード/支援技術から操作不能）" % (t["name"], " / ".join(missing)),
+                    fix="<button type=\"button\"> に置き換える（推奨）。やむを得ない場合は role/tabIndex/onKeyDown を揃える",
+                    snippet=snippet,
+                )
+
+        # button / a / summary need an accessible name
+        if lname in WEB_CONTROLS:
+            interactive_seen += 1
+            body = inner_text(t)
+            body_text = re.sub(r"<[^>]*>", " ", body).strip()
+            body_wordish = bool(WORDISH_RE.search(body_text))
+            dynamic_body = ("{" in body and "}" in body) or ("<?" in body)
+            child_named = re.search(r"(aria-label|alt)\s*=", body) is not None
+            explicit_name = attr_names(attrs, WEB_NAME_ATTRS)
+            named = explicit_name or body_wordish or dynamic_body or child_named
+            symbol_only_body = bool(body_text) and is_symbol_only(body_text)
+            if named:
+                pass  # an accessible name exists (explicit attr, text, or dynamic expression)
+            elif symbol_only_body:
+                # The glyph IS the label — more specific (and more actionable) than "no name".
+                emit(
+                    rule=prefix + "-SYMBOL-LABEL",
+                    severity=ERROR,
+                    file=rel,
+                    line=t["line"],
+                    message="<%s> のラベルが記号のみ（%r）— 読み上げが記号名になる" % (t["name"], body_text[:12]),
+                    fix='aria-label="閉じる" 等を付け、記号側は aria-hidden="true"',
+                    snippet=snippet,
+                )
+            else:
+                emit(
+                    rule=prefix + "-CONTROL-NAME",
+                    severity=ERROR,
+                    file=rel,
+                    line=t["line"],
+                    message="<%s> に accessible name が無い（アイコンのみ等・読み上げで用途が伝わらない）" % t["name"],
+                    fix='aria-label="操作の意味" を付ける（アイコンには aria-hidden="true"）',
+                    snippet=snippet,
+                )
+
+        # form controls need a name
+        if lname in WEB_FIELDS:
+            typ = attrs.get("type")
+            if isinstance(typ, str) and typ.strip().strip("\"'") in ("hidden", "submit", "button", "image"):
+                continue
+            has_name = attr_names(attrs, ("aria-label", "aria-labelledby", "title"))
+            raw_id = attrs.get("id")
+            id_val = raw_id.strip().strip("{}\"'") if isinstance(raw_id, str) else ""
+            has_id = bool(id_val)
+            label_matched = (has_id and id_val in label_for_ids) or wrapped_by_named_label(t["start"])
+            if label_matched:
+                continue
+            if not has_name and not has_id:
+                emit(
+                    rule=prefix + "-FIELD-NAME",
+                    severity=ERROR,
+                    file=rel,
+                    line=t["line"],
+                    message="<%s> に accessible name が無い（label 関連付けも aria-label も無い）" % t["name"],
+                    fix='<label for="x"> と id="x" を対応させる / aria-label="項目名"',
+                    snippet=snippet,
+                )
+            elif not has_name and has_id:
+                emit(
+                    rule=prefix + "-FIELD-LABEL-UNVERIFIED",
+                    severity=WARN,
+                    file=rel,
+                    line=t["line"],
+                    message="<%s> は id はあるが対応する <label for> を静的に確認できない" % t["name"],
+                    fix="同一テンプレート内に <label for> があるか確認（無ければ aria-label を付ける）",
+                    snippet=snippet,
+                )
+
+    return {"interactive": interactive_seen}
+
+
+# ---------------------------------------------------------------------------
+# Project-level checks (a11y regression harness must exist)
+# ---------------------------------------------------------------------------
+
+def scan_project(root, emit, files):
+    """Presence checks that make a11y a *standing* property of the repo, not a
+    one-off fix: a large-text regression test for Flutter, an a11y linter for web."""
+    has_pubspec = os.path.isfile(os.path.join(root, "pubspec.yaml"))
+    has_pkg = os.path.isfile(os.path.join(root, "package.json"))
+
+    if has_pubspec:
+        found = False
+        for dirpath, dirnames, filenames in os.walk(root):
+            dirnames[:] = [d for d in dirnames if d not in (".git", "node_modules", ".dart_tool", "build")]
+            rel_dir = os.path.relpath(dirpath, root).replace(os.sep, "/")
+            if not (rel_dir.startswith("test") or rel_dir.startswith("integration_test") or "/test" in "/" + rel_dir):
+                continue
+            for fn in filenames:
+                if not fn.endswith(".dart"):
+                    continue
+                body = read_text(os.path.join(dirpath, fn)) or ""
+                # `textScaleFactor` is deprecated and must not count as "we test large
+                # text" — accepting it would bless the API that is going away.
+                if re.search(r"TextScaler|textScalerOf|textScaler\s*:", body):
+                    found = True
+                    break
+            if found:
+                break
+        if not found:
+            emit(
+                rule="A11Y-PROJ-SCALE-TEST",
+                severity=WARN,
+                file="pubspec.yaml",
+                line=1,
+                message="最大文字サイズ（Dynamic Type）を再現する自動テストが見つからない（拡大時のレイアウト崩れが回帰検知されない）",
+                fix="examples/a11y/flutter/a11y_smoke_test.dart を test/ にコピーして配線する",
+                snippet="pubspec.yaml",
+            )
+
+    # A WordPress theme with a build-tooling package.json is not a React app; asking
+    # it for a JSX linter is noise. Only projects that actually ship .tsx/.jsx qualify.
+    has_react_files = any(rel.endswith(WEB_EXT) for rel, _full in files)
+
+    if has_pkg and has_react_files:
+        # Monorepos keep the lint config in apps/*/ or packages/*/, so a root-only
+        # look would report "no a11y linter" on a repo that has one per workspace.
+        blob_parts = []
+        search_dirs = [root]
+        for parent in ("apps", "packages", "web", "frontend"):
+            pdir = os.path.join(root, parent)
+            if os.path.isdir(pdir):
+                for child in sorted(os.listdir(pdir))[:20]:
+                    cdir = os.path.join(pdir, child)
+                    if os.path.isdir(cdir):
+                        search_dirs.append(cdir)
+        for d in search_dirs:
+            try:
+                entries = os.listdir(d)
+            except OSError:
+                continue
+            for f in entries:
+                if f == "package.json" or f.startswith(".eslintrc") or f.startswith("eslint.config."):
+                    blob_parts.append(read_text(os.path.join(d, f)) or "")
+        blob = "".join(blob_parts)
+        has_jsx_a11y = "jsx-a11y" in blob
+        has_next_preset = "eslint-config-next" in blob or "next/core-web-vitals" in blob
+        if not has_jsx_a11y and not has_next_preset:
+            emit(
+                rule="A11Y-PROJ-WEB-LINT",
+                severity=WARN,
+                file="package.json",
+                line=1,
+                message="a11y linter（eslint-plugin-jsx-a11y 等）が設定に見つからない（ARIA/alt/キーボードの回帰が検知されない）",
+                fix="examples/a11y/web/eslint-a11y.config.md の設定を追加する",
+                snippet="package.json",
+            )
+        elif not has_jsx_a11y and has_next_preset:
+            # eslint-config-next bundles jsx-a11y but enables only a small subset, so
+            # "we use next lint" is not the same as "a11y is linted".
+            emit(
+                rule="A11Y-PROJ-WEB-LINT-SUBSET",
+                severity=WARN,
+                file="package.json",
+                line=1,
+                message="a11y lint が Next.js 既定の一部ルールのみ（jsx-a11y の recommended/strict が未適用）",
+                fix="jsx-a11y の recommended を明示的に有効化し、severity を error にする（examples/a11y/web/eslint-a11y.config.md）",
+                snippet="package.json",
+            )
+
+
+# ---------------------------------------------------------------------------
+# Scan driver
+# ---------------------------------------------------------------------------
+
+def scan_tree(root, excludes=None, rules=None, project_checks=True):
+    """Returns (findings, stats). findings are dicts; stats carries denominators."""
+    excludes = list(DEFAULT_EXCLUDES) + list(excludes or [])
+    files = iter_files(root, excludes)
+
+    findings = []
+    ignored = 0
+    bare_pragma = 0
+    stats = {
+        "files_scanned": 0,
+        "by_ext": {},
+        "interactive_elements": 0,
+        "unreadable": 0,
+    }
+
+    lines_cache = {}
+
+    def make_emit(rel, text):
+        def emit(rule, severity, file, line, message, fix, snippet):
+            if rules and rule not in rules:
+                return
+            lines = lines_cache.get(rel)
+            if lines is None:
+                lines = text.splitlines()
+                lines_cache[rel] = lines
+            ctx = ""
+            for ln in (line - 1, line - 2):
+                if 0 <= ln < len(lines):
+                    ctx += lines[ln] + "\n"
+            m = IGNORE_RE.search(ctx)
+            if m and m.group(1).strip():
+                nonlocal_counter["ignored"] += 1
+                return
+            if IGNORE_BARE_RE.search(ctx) and not m:
+                nonlocal_counter["bare"] += 1
+            findings.append({
+                "rule": rule,
+                "severity": severity,
+                "file": file,
+                "line": line,
+                "message": message,
+                "fix": fix,
+                "fingerprint": hashlib.sha1(
+                    ("%s|%s|%s" % (rule, file, snippet)).encode("utf-8")
+                ).hexdigest()[:12],
+            })
+        return emit
+
+    nonlocal_counter = {"ignored": 0, "bare": 0}
+
+    for rel, full in files:
+        text = read_text(full)
+        if text is None:
+            stats["unreadable"] += 1
+            continue
+        ext = os.path.splitext(rel)[1]
+        stats["files_scanned"] += 1
+        stats["by_ext"][ext] = stats["by_ext"].get(ext, 0) + 1
+        emit = make_emit(rel, text)
+        try:
+            if ext in DART_EXT:
+                sub = scan_dart(rel, text, emit)
+            elif ext in WEB_EXT:
+                sub = scan_markup(rel, text, php=False, emit=emit)
+            else:
+                sub = scan_markup(rel, text, php=True, emit=emit)
+        except RecursionError:
+            stats["unreadable"] += 1
+            continue
+        stats["interactive_elements"] += sub.get("interactive", 0)
+
+    if project_checks:
+        proj_emit = make_emit("<project>", "")
+        scan_project(root, proj_emit, files)
+
+    ignored = nonlocal_counter["ignored"]
+    bare_pragma = nonlocal_counter["bare"]
+    stats["ignored"] = ignored
+    stats["bare_pragma"] = bare_pragma
+
+    # Deterministic order + ordinal so repeated identical snippets stay distinct.
+    findings.sort(key=lambda f: (f["file"], f["line"], f["rule"]))
+    seen = {}
+    for f in findings:
+        key = (f["rule"], f["file"], f["fingerprint"])
+        seen[key] = seen.get(key, 0) + 1
+        f["key"] = "%s|%s|%s|%d" % (f["rule"], f["file"], f["fingerprint"], seen[key])
+
+    return findings, stats
+
+
+# ---------------------------------------------------------------------------
+# Baseline (ratchet)
+# ---------------------------------------------------------------------------
+
+def load_baseline(path):
+    with open(path, "r", encoding="utf-8") as fh:
+        data = json.load(fh)
+    if not isinstance(data, dict) or not isinstance(data.get("findings"), list):
+        raise ValueError("baseline must be an object with findings[]")
+    return data
+
+
+def baseline_error_count(data):
+    counts = data.get("counts") or {}
+    if isinstance(counts, dict) and isinstance(counts.get(ERROR), int):
+        return counts[ERROR]
+    return len(data.get("findings", []))
+
+
+def build_baseline(findings, stats):
+    errs = [f for f in findings if f["severity"] == ERROR]
+    warns = [f for f in findings if f["severity"] == WARN]
+    return {
+        "schemaVersion": SCHEMA_VERSION,
+        "note": (
+            "既知の a11y 違反スナップショット（ratchet 用）。新規違反のみ CI を落とす。"
+            "件数は減る方向にのみ更新してよい — 増やす更新は --allow-baseline-growth が必要で、理由の記載が前提。"
+        ),
+        "counts": {ERROR: len(errs), WARN: len(warns)},
+        "scanned": {"files": stats.get("files_scanned", 0), "interactive": stats.get("interactive_elements", 0)},
+        "findings": sorted(f["key"] for f in findings),
+    }
+
+
+# ---------------------------------------------------------------------------
+# Report
+# ---------------------------------------------------------------------------
+
+def format_text_report(root, findings, stats, new_keys, baseline, strict):
+    lines = []
+    lines.append("root: %s" % root)
+    ext_summary = ", ".join("%s=%d" % (k, v) for k, v in sorted(stats["by_ext"].items())) or "(none)"
+    lines.append("scanned: %d files (%s) / interactive elements inspected: %d"
+                 % (stats["files_scanned"], ext_summary, stats["interactive_elements"]))
+    if stats.get("ignored"):
+        lines.append("suppressed by `a11y-ignore: <reason>`: %d" % stats["ignored"])
+    if stats.get("bare_pragma"):
+        lines.append("NOTE: %d bare `a11y-ignore` without a reason — these do NOT suppress" % stats["bare_pragma"])
+    if stats.get("unreadable"):
+        lines.append("unreadable files: %d" % stats["unreadable"])
+
+    if stats["files_scanned"] == 0:
+        lines.append("")
+        lines.append("UNKNOWN: 走査対象 0 件 — これはゼロ違反ではない（--root / --exclude を確認）")
+        return "\n".join(lines)
+
+    errs = [f for f in findings if f["severity"] == ERROR]
+    warns = [f for f in findings if f["severity"] == WARN]
+    lines.append("findings: %d error / %d warn" % (len(errs), len(warns)))
+
+    if baseline is not None:
+        known = set(baseline.get("findings", []))
+        current = set(f["key"] for f in findings)
+        lines.append("baseline: %d known / %d new / %d fixed (prune with --update-baseline)"
+                     % (len(known), len(new_keys), len(known - current)))
+
+    by_rule = {}
+    by_file = {}
+    for f in findings:
+        by_rule[f["rule"]] = by_rule.get(f["rule"], 0) + 1
+        by_file[f["file"]] = by_file.get(f["file"], 0) + 1
+    if by_rule:
+        lines.append("by rule: " + ", ".join("%s=%d" % (k, v) for k, v in sorted(by_rule.items())))
+    if len(by_file) > 1:
+        top = sorted(by_file.items(), key=lambda kv: (-kv[1], kv[0]))[:5]
+        lines.append("top files: " + ", ".join("%s=%d" % (k, v) for k, v in top))
+
+    shown = [f for f in findings if (baseline is None or f["key"] in new_keys)]
+    if shown:
+        lines.append("")
+        label = "NEW findings" if baseline is not None else "findings"
+        lines.append("%s:" % label)
+        for f in shown:
+            lines.append("  %s:%d: %s [%s] %s" % (f["file"], f["line"], f["severity"].upper(), f["rule"], f["message"]))
+            lines.append("      → fix: %s" % f["fix"])
+
+    fatal = [f for f in shown if f["severity"] == ERROR or strict]
+    lines.append("")
+    if fatal:
+        lines.append("FAIL: %d 件の%s違反（%s）" % (
+            len(fatal),
+            "新規" if baseline is not None else "",
+            "error" + (" + warn (--strict)" if strict else ""),
+        ))
+        lines.append("静的に検出できない部分（読み上げでの通し操作・最大文字サイズのレイアウト）は"
+                     "自動テストと実機確認で別途担保すること。")
+    else:
+        lines.append("OK: 新規の静的 a11y 違反なし（= アクセシブルであることの証明ではない）")
+    return "\n".join(lines)
+
+
+# ---------------------------------------------------------------------------
+# Self-test (hermetic)
+# ---------------------------------------------------------------------------
+
+FIX_DART_VIOLATING = """
+import 'package:flutter/material.dart';
+
+class Bad extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      children: [
+        // icon-only tap target with no name at all
+        GestureDetector(
+          onTap: () => go('/diary'),
+          child: SizedBox(
+            width: 44,
+            height: 44,
+            child: const Center(child: Icon(Icons.book)),
+          ),
+        ),
+        // symbol-only label ('<' reads as "less than")
+        GestureDetector(
+          onTap: () => pop(),
+          child: const Text('<'),
+        ),
+        // named by its text but no button role, and enabled state not exposed
+        GestureDetector(
+          onTap: enabled ? onTap : null,
+          child: Text(label),
+        ),
+        // unnamed text field (hintText is empty)
+        TextField(
+          controller: _c,
+          decoration: InputDecoration(hintText: ''),
+        ),
+        // unlabelled toggle
+        Switch(value: v, onChanged: (x) {}),
+        // informative image with no semanticLabel
+        Image.asset('assets/hero.png'),
+      ],
+    );
+  }
+}
+"""
+
+FIX_DART_CLEAN = """
+import 'package:flutter/material.dart';
+
+class Good extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      children: [
+        Semantics(
+          button: true,
+          label: '日記を開く',
+          child: GestureDetector(
+            onTap: () => go('/diary'),
+            child: const Icon(Icons.book),
+          ),
+        ),
+        Semantics(
+          button: true,
+          label: '戻る',
+          child: GestureDetector(
+            onTap: () => pop(),
+            child: const ExcludeSemantics(child: Text('<')),
+          ),
+        ),
+        Semantics(
+          button: true,
+          enabled: enabled,
+          label: 'ログイン',
+          child: GestureDetector(
+            onTap: enabled ? onTap : null,
+            child: Text(label),
+          ),
+        ),
+        TextField(
+          controller: _c,
+          decoration: const InputDecoration(labelText: 'メッセージ'),
+        ),
+        SwitchListTile(
+          title: const Text('通知'),
+          value: v,
+          onChanged: (x) {},
+        ),
+        Image.asset('assets/hero.png', semanticLabel: '海の写真'),
+        IconButton(
+          tooltip: '共有',
+          onPressed: share,
+          icon: const Icon(Icons.share),
+        ),
+      ],
+    );
+  }
+}
+"""
+
+FIX_TSX_VIOLATING = """
+export function Bad() {
+  return (
+    <div>
+      <div onClick={() => save()}>保存</div>
+      <button onClick={close}><Icon name="x" /></button>
+      <img src="/hero.png" />
+      <input type="text" />
+      <a href="/next">×</a>
+    </div>
+  );
+}
+"""
+
+FIX_TSX_CLEAN = """
+export function Good() {
+  return (
+    <div>
+      <button type="button" onClick={() => save()}>保存</button>
+      <button type="button" aria-label="閉じる" onClick={close}>
+        <Icon name="x" aria-hidden="true" />
+      </button>
+      <img src="/hero.png" alt="海の写真" />
+      <img src="/deco.png" alt="" />
+      <label htmlFor="q">検索</label>
+      <input id="q" type="text" aria-label="検索語" />
+      <a href="/next">次へ</a>
+      <div role="button" tabIndex={0} onClick={save} onKeyDown={onKey}>代替</div>
+    </div>
+  );
+}
+"""
+
+# Regression fixtures for false positives found while validating this gate against
+# real i-Willink repos. Each one used to be reported and must stay silent.
+FIX_TSX_LABEL_FORMS = """
+export function Forms() {
+  return (
+    <form>
+      {/* implicit association: the label wraps the input, no id needed */}
+      <label>
+        Campaign ID
+        <input value={v} onChange={set} placeholder="issue-003" />
+      </label>
+      {/* explicit association: for/htmlFor points at the id */}
+      <label htmlFor="subject">件名</label>
+      <input id="subject" type="text" />
+    </form>
+  );
+}
+"""
+
+FIX_TSX_CODE_SAMPLE = """
+const snippet = `
+<Button asChild>
+  <Link href="/dashboard">ダッシュボードへ</Link>
+</Button>
+<img src="/x.png" />
+<input type="text" />
+`;
+
+export function Docs() {
+  return <pre>{snippet}</pre>;
+}
+"""
+
+FIX_PHP_VIOLATING = """
+<div class="card">
+  <img src="<?php echo esc_url( $url ); ?>">
+  <a href="#"></a>
+  <input type="search" name="s">
+</div>
+"""
+
+FIX_MARKUP_VIEWPORT = """
+<head>
+  <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no">
+</head>
+<body>
+  <a href="/a" tabindex="3">先に読ませたいリンク</a>
+</body>
+"""
+
+FIX_MARKUP_VIEWPORT_OK = """
+<head>
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+</head>
+<body>
+  <a href="/a" tabindex="0">リンク</a>
+  <div tabindex="-1">プログラム的にのみ focus</div>
+</body>
+"""
+
+FIX_PHP_CLEAN = """
+<div class="card">
+  <img src="<?php echo esc_url( $url ); ?>" alt="<?php echo esc_attr( $alt ); ?>">
+  <a href="<?php echo esc_url( $link ); ?>"><?php echo esc_html( $title ); ?></a>
+  <label for="s">検索</label>
+  <input type="search" id="s" name="s">
+</div>
+"""
+
+FIX_DART_IGNORED = """
+class Ignored extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    // a11y-ignore: 装飾用のヒット領域で、同じ操作が上のボタンで提供されている
+    return GestureDetector(onTap: noop, child: const Icon(Icons.circle));
+  }
+}
+"""
+
+FIX_DART_BARE_IGNORE = """
+class BareIgnore extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    // a11y-ignore
+    return GestureDetector(onTap: noop, child: const Icon(Icons.circle));
+  }
+}
+"""
+
+
+def _write(base, rel, content):
+    full = os.path.join(base, rel.replace("/", os.sep))
+    os.makedirs(os.path.dirname(full), exist_ok=True)
+    with open(full, "w", encoding="utf-8") as fh:
+        fh.write(content)
+
+
+def _rules(findings):
+    out = {}
+    for f in findings:
+        out[f["rule"]] = out.get(f["rule"], 0) + 1
+    return out
+
+
+def run_self_test():
+    import tempfile
+
+    checks = []
+
+    def check(name, ok, detail=""):
+        checks.append((name, ok, detail))
+
+    with tempfile.TemporaryDirectory() as td:
+        # --- Flutter: violating fixture -------------------------------------
+        d1 = os.path.join(td, "flutter_bad")
+        _write(d1, "lib/bad.dart", FIX_DART_VIOLATING)
+        f1, s1 = scan_tree(d1, project_checks=False)
+        r1 = _rules(f1)
+        check("dart violating: NAME x1", r1.get("A11Y-FLUTTER-NAME") == 1, str(r1))
+        check("dart violating: SYMBOL-LABEL x1", r1.get("A11Y-FLUTTER-SYMBOL-LABEL") == 1, str(r1))
+        check("dart violating: ROLE x1", r1.get("A11Y-FLUTTER-ROLE") == 1, str(r1))
+        check("dart violating: STATE warn x1", r1.get("A11Y-FLUTTER-STATE") == 1, str(r1))
+        check("dart violating: FIELD-NAME x1", r1.get("A11Y-FLUTTER-FIELD-NAME") == 1, str(r1))
+        check("dart violating: TOGGLE-NAME x1", r1.get("A11Y-FLUTTER-TOGGLE-NAME") == 1, str(r1))
+        check("dart violating: IMAGE-LABEL warn x1", r1.get("A11Y-FLUTTER-IMAGE-LABEL") == 1, str(r1))
+        check("dart violating: interactive counted", s1["interactive_elements"] >= 3, str(s1))
+
+        # --- Flutter: clean fixture -----------------------------------------
+        d2 = os.path.join(td, "flutter_good")
+        _write(d2, "lib/good.dart", FIX_DART_CLEAN)
+        f2, s2 = scan_tree(d2, project_checks=False)
+        check("dart clean: 0 findings", len(f2) == 0, str(_rules(f2)))
+        check("dart clean: files scanned = 1", s2["files_scanned"] == 1, str(s2))
+
+        # --- Web (TSX) ------------------------------------------------------
+        d3 = os.path.join(td, "web_bad")
+        _write(d3, "src/Bad.tsx", FIX_TSX_VIOLATING)
+        f3, _s3 = scan_tree(d3, project_checks=False)
+        r3 = _rules(f3)
+        check("tsx violating: INTERACTIVE-DIV x1", r3.get("A11Y-WEB-INTERACTIVE-DIV") == 1, str(r3))
+        check("tsx violating: CONTROL-NAME x1", r3.get("A11Y-WEB-CONTROL-NAME") == 1, str(r3))
+        check("tsx violating: IMG-ALT x1", r3.get("A11Y-WEB-IMG-ALT") == 1, str(r3))
+        check("tsx violating: FIELD-NAME x1", r3.get("A11Y-WEB-FIELD-NAME") == 1, str(r3))
+        check("tsx violating: SYMBOL-LABEL x1", r3.get("A11Y-WEB-SYMBOL-LABEL") == 1, str(r3))
+
+        d4 = os.path.join(td, "web_good")
+        _write(d4, "src/Good.tsx", FIX_TSX_CLEAN)
+        f4, _s4 = scan_tree(d4, project_checks=False)
+        errs4 = [f for f in f4 if f["severity"] == ERROR]
+        check("tsx clean: 0 errors", len(errs4) == 0, str(_rules(f4)))
+
+        # --- Markup (PHP) ---------------------------------------------------
+        d5 = os.path.join(td, "php_bad")
+        _write(d5, "theme/card.php", FIX_PHP_VIOLATING)
+        f5, _s5 = scan_tree(d5, project_checks=False)
+        r5 = _rules(f5)
+        check("php violating: IMG-ALT x1", r5.get("A11Y-MARKUP-IMG-ALT") == 1, str(r5))
+        check("php violating: CONTROL-NAME x1", r5.get("A11Y-MARKUP-CONTROL-NAME") == 1, str(r5))
+        check("php violating: FIELD-NAME x1", r5.get("A11Y-MARKUP-FIELD-NAME") == 1, str(r5))
+
+        d6 = os.path.join(td, "php_good")
+        _write(d6, "theme/card.php", FIX_PHP_CLEAN)
+        f6, _s6 = scan_tree(d6, project_checks=False)
+        errs6 = [f for f in f6 if f["severity"] == ERROR]
+        check("php clean: 0 errors (php echo counts as a name)", len(errs6) == 0, str(_rules(f6)))
+
+        # --- clamp floor + unknown-ctor drift guard --------------------------
+        d25 = os.path.join(td, "clamp")
+        _write(d25, "lib/app.dart",
+               "class App extends StatelessWidget {\n"
+               "  @override\n"
+               "  Widget build(BuildContext c) => MaterialApp(\n"
+               "    builder: (c, child) => MediaQuery.withClampedTextScaling(maxScaleFactor: 1.6, child: child!),\n"
+               "  );\n"
+               "}\n")
+        f25, _s25 = scan_tree(d25, project_checks=False)
+        check("dart: clamping below 200% is an error",
+              _rules(f25).get("A11Y-FLUTTER-SCALE-CLAMP") == 1, str(_rules(f25)))
+
+        d26 = os.path.join(td, "clamp_ok")
+        _write(d26, "lib/app.dart",
+               "class App extends StatelessWidget {\n"
+               "  @override\n"
+               "  Widget build(BuildContext c) => MaterialApp(\n"
+               "    builder: (c, child) => MediaQuery.withClampedTextScaling(maxScaleFactor: 2.0, child: child!),\n"
+               "  );\n"
+               "}\n")
+        f26, _s26 = scan_tree(d26, project_checks=False)
+        check("dart: clamping at 200% is clean",
+              _rules(f26).get("A11Y-FLUTTER-SCALE-CLAMP") is None, str(_rules(f26)))
+
+        d27 = os.path.join(td, "unknown_ctor")
+        _write(d27, "lib/x.dart",
+               "class X extends StatelessWidget {\n"
+               "  @override\n"
+               "  Widget build(BuildContext c) => ProjectSpecificTappable(onTap: go, child: const Icon(Icons.add));\n"
+               "}\n")
+        f27, _s27 = scan_tree(d27, project_checks=False)
+        check("dart: an unclassified tappable ctor is reported, not silently skipped",
+              _rules(f27).get("A11Y-FLUTTER-UNKNOWN-TAP-CTOR") == 1, str(_rules(f27)))
+
+        d28 = os.path.join(td, "scale_test_deprecated")
+        _write(d28, "pubspec.yaml", "name: demo\n")
+        _write(d28, "lib/app.dart", "class A {}\n")
+        _write(d28, "test/old_test.dart", "void main() { const x = 3.0; /* textScaleFactor */ }\n")
+        f28, _s28 = scan_tree(d28, project_checks=True)
+        check("project: a deprecated textScaleFactor test does not satisfy the large-text check",
+              _rules(f28).get("A11Y-PROJ-SCALE-TEST") == 1, str(_rules(f28)))
+
+        # --- viewport zoom lock + positive tabindex --------------------------
+        d22 = os.path.join(td, "viewport")
+        _write(d22, "theme/header.php", FIX_MARKUP_VIEWPORT)
+        f22, _s22 = scan_tree(d22, project_checks=False)
+        r22 = _rules(f22)
+        check("markup: zoom-locked viewport is an error", r22.get("A11Y-MARKUP-VIEWPORT-ZOOM") == 1, str(r22))
+        check("markup: positive tabindex is an error", r22.get("A11Y-MARKUP-POSITIVE-TABINDEX") == 1, str(r22))
+
+        d23 = os.path.join(td, "viewport_ok")
+        _write(d23, "theme/header.php", FIX_MARKUP_VIEWPORT_OK)
+        f23, _s23 = scan_tree(d23, project_checks=False)
+        check("markup: zoomable viewport + tabindex 0/-1 are clean", len(f23) == 0, str(_rules(f23)))
+
+        d24 = os.path.join(td, "proj_next_subset")
+        _write(d24, "package.json", '{"name":"demo","devDependencies":{"eslint-config-next":"^16"}}\n')
+        _write(d24, "src/Page.tsx", "export const P = () => <button type=\"button\">保存</button>;\n")
+        f24, _s24 = scan_tree(d24, project_checks=True)
+        r24 = _rules(f24)
+        check("project: Next.js preset alone is flagged as a subset, not as absent",
+              r24.get("A11Y-PROJ-WEB-LINT-SUBSET") == 1 and r24.get("A11Y-PROJ-WEB-LINT") is None, str(r24))
+
+        # --- false-positive regressions (found on real repos) ---------------
+        d18 = os.path.join(td, "web_labels")
+        _write(d18, "src/Forms.tsx", FIX_TSX_LABEL_FORMS)
+        f18, s18 = scan_tree(d18, project_checks=False)
+        check("tsx: implicit + explicit <label> association is a name",
+              len(f18) == 0 and s18["files_scanned"] == 1, str(_rules(f18)))
+
+        d19 = os.path.join(td, "web_code_sample")
+        _write(d19, "src/Docs.tsx", FIX_TSX_CODE_SAMPLE)
+        f19, s19 = scan_tree(d19, project_checks=False)
+        check("tsx: JSX inside a template literal is not scanned",
+              len(f19) == 0 and s19["files_scanned"] == 1, str(_rules(f19)))
+
+        d21 = os.path.join(td, "proj_wp_theme")
+        _write(d21, "package.json", '{"name":"theme","devDependencies":{"tailwindcss":"^3"}}\n')
+        _write(d21, "header.php", "<header><a href=\"/\">Home</a></header>\n")
+        f21, _s21 = scan_tree(d21, project_checks=True)
+        check("project: PHP theme with a build package.json is not asked for a JSX linter",
+              _rules(f21).get("A11Y-PROJ-WEB-LINT") is None, str(_rules(f21)))
+
+        d20 = os.path.join(td, "proj_monorepo")
+        _write(d20, "package.json", '{"name":"root","workspaces":["apps/*"]}\n')
+        _write(d20, "apps/web/eslint.config.mjs", 'import next from "eslint-config-next/core-web-vitals";\n')
+        _write(d20, "apps/web/src/Page.tsx", "export const P = () => <button type=\"button\">保存</button>;\n")
+        f20, _s20 = scan_tree(d20, project_checks=True)
+        check("project: monorepo workspace lint config is found",
+              _rules(f20).get("A11Y-PROJ-WEB-LINT") is None, str(_rules(f20)))
+
+        # --- suppression pragma --------------------------------------------
+        d7 = os.path.join(td, "pragma")
+        _write(d7, "lib/ignored.dart", FIX_DART_IGNORED)
+        f7, s7 = scan_tree(d7, project_checks=False)
+        check("pragma with reason suppresses", len(f7) == 0 and s7["ignored"] == 1, "%s %s" % (_rules(f7), s7))
+
+        d8 = os.path.join(td, "pragma_bare")
+        _write(d8, "lib/bare.dart", FIX_DART_BARE_IGNORE)
+        f8, s8 = scan_tree(d8, project_checks=False)
+        check("bare pragma does NOT suppress", len(f8) == 1 and s8["bare_pragma"] == 1, "%s %s" % (_rules(f8), s8))
+
+        # --- exclusions (generated + test code) -----------------------------
+        d9 = os.path.join(td, "excluded")
+        _write(d9, "lib/model.g.dart", FIX_DART_VIOLATING)
+        _write(d9, "test/widget_test.dart", FIX_DART_VIOLATING)
+        f9, s9 = scan_tree(d9, project_checks=False)
+        check("generated + test excluded -> 0 files scanned", s9["files_scanned"] == 0 and len(f9) == 0, str(s9))
+
+        # --- ratchet: baseline suppresses known, catches new ----------------
+        base = build_baseline(f1, s1)
+        errs1 = [f for f in f1 if f["severity"] == ERROR]
+        check("baseline counts errors", baseline_error_count(base) == len(errs1), str(base["counts"]))
+        current_keys = set(f["key"] for f in f1)
+        new_keys = current_keys - set(base["findings"])
+        check("baseline: no new findings on identical tree", len(new_keys) == 0, str(new_keys))
+
+        d10 = os.path.join(td, "flutter_bad_plus")
+        _write(d10, "lib/bad.dart", FIX_DART_VIOLATING)
+        _write(d10, "lib/extra.dart",
+               "class E extends StatelessWidget {\n"
+               "  @override\n"
+               "  Widget build(BuildContext c) => GestureDetector(onTap: go, child: const Icon(Icons.add));\n"
+               "}\n")
+        f10, s10 = scan_tree(d10, project_checks=False)
+        new10 = set(f["key"] for f in f10) - set(base["findings"])
+        check("baseline: a new violation is NEW", len(new10) == 1, str(new10))
+
+        # fingerprint stability: shifting lines must not create a NEW finding
+        d11 = os.path.join(td, "flutter_bad_shifted")
+        _write(d11, "lib/bad.dart", "// leading comment\n// another\n" + FIX_DART_VIOLATING)
+        f11, _s11 = scan_tree(d11, project_checks=False)
+        new11 = set(f["key"] for f in f11) - set(base["findings"])
+        check("fingerprint stable under line shift", len(new11) == 0, str(new11))
+
+        # anti-gaming: a baseline that grows is refused unless allowed
+        grown = build_baseline(f10, s10)
+        check("baseline growth detectable",
+              baseline_error_count(grown) > baseline_error_count(base),
+              "%s > %s" % (baseline_error_count(grown), baseline_error_count(base)))
+
+        # --- empty tree = UNKNOWN, not zero --------------------------------
+        d12 = os.path.join(td, "empty")
+        os.makedirs(d12, exist_ok=True)
+        f12, s12 = scan_tree(d12, project_checks=False)
+        check("empty tree: 0 files scanned (=> UNKNOWN exit 3)", s12["files_scanned"] == 0 and len(f12) == 0, str(s12))
+
+        # --- project-level checks ------------------------------------------
+        d13 = os.path.join(td, "proj_flutter")
+        _write(d13, "pubspec.yaml", "name: demo\n")
+        _write(d13, "lib/app.dart", "class A {}\n")
+        f13, _s13 = scan_tree(d13, project_checks=True)
+        check("project: missing large-text test warns",
+              _rules(f13).get("A11Y-PROJ-SCALE-TEST") == 1, str(_rules(f13)))
+
+        d14 = os.path.join(td, "proj_flutter_ok")
+        _write(d14, "pubspec.yaml", "name: demo\n")
+        _write(d14, "lib/app.dart", "class A {}\n")
+        _write(d14, "test/a11y_test.dart",
+               "void main() { const TextScaler.linear(3.0); }\n")
+        f14, _s14 = scan_tree(d14, project_checks=True)
+        check("project: large-text test present -> no warn",
+              _rules(f14).get("A11Y-PROJ-SCALE-TEST") is None, str(_rules(f14)))
+
+        d15 = os.path.join(td, "proj_web")
+        _write(d15, "package.json", '{"name":"demo","devDependencies":{}}\n')
+        _write(d15, "src/Page.tsx", "export const P = () => <button type=\"button\">保存</button>;\n")
+        f15, _s15 = scan_tree(d15, project_checks=True)
+        check("project: missing a11y linter warns",
+              _rules(f15).get("A11Y-PROJ-WEB-LINT") == 1, str(_rules(f15)))
+
+        d16 = os.path.join(td, "proj_web_ok")
+        _write(d16, "package.json", '{"name":"demo","devDependencies":{"eslint-plugin-jsx-a11y":"^6"}}\n')
+        _write(d16, "src/Page.tsx", "export const P = () => <button type=\"button\">保存</button>;\n")
+        f16, _s16 = scan_tree(d16, project_checks=True)
+        check("project: a11y linter present -> no warn",
+              _rules(f16).get("A11Y-PROJ-WEB-LINT") is None, str(_rules(f16)))
+
+        # --- rule filter ----------------------------------------------------
+        f17, _s17 = scan_tree(d1, rules={"A11Y-FLUTTER-NAME"}, project_checks=False)
+        check("--rules filter keeps only the asked rule",
+              set(_rules(f17).keys()) == {"A11Y-FLUTTER-NAME"}, str(_rules(f17)))
+
+    all_ok = True
+    for name, ok, detail in checks:
+        print("[self-test] %-52s -> %s%s" % (name, "OK" if ok else "FAIL", "" if ok else "  (%s)" % detail))
+        all_ok = all_ok and ok
+    print("[self-test] %d checks" % len(checks))
+    if all_ok:
+        print("[self-test] RESULT: PASS")
+        return 0
+    print("[self-test] RESULT: FAIL")
+    return 1
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+def main():
+    ap = argparse.ArgumentParser(
+        description="Accessibility static gate: detect interactive elements without an "
+                    "accessible name / role / state across Flutter, React and PHP templates "
+                    "(detection only — fixing is a human's job)."
+    )
+    ap.add_argument("--root", help="directory tree to scan")
+    ap.add_argument("--baseline", help="known-violation snapshot (ratchet mode)")
+    ap.add_argument("--update-baseline", action="store_true", help="rewrite the baseline from this scan")
+    ap.add_argument("--allow-baseline-growth", action="store_true",
+                    help="permit writing a baseline with MORE errors than before (must be justified)")
+    ap.add_argument("--strict", action="store_true", help="warnings fail too")
+    ap.add_argument("--format", choices=("text", "json"), default="text")
+    ap.add_argument("--exclude", action="append", default=[], help="extra path substring to skip (repeatable)")
+    ap.add_argument("--rules", help="comma-separated rule ids to run (default: all)")
+    ap.add_argument("--no-project-checks", action="store_true", help="skip repo-level presence checks")
+    ap.add_argument("--self-test", action="store_true", help="hermetic deterministic self-check")
+    args = ap.parse_args()
+
+    if args.self_test:
+        sys.exit(run_self_test())
+
+    if not args.root:
+        sys.stderr.write("usage: --root <dir> [--baseline <file>] (or --self-test)\n")
+        sys.exit(2)
+    if not os.path.isdir(args.root):
+        sys.stderr.write("root not a directory: %s\n" % args.root)
+        sys.exit(2)
+    if args.update_baseline and not args.baseline:
+        sys.stderr.write("--update-baseline requires --baseline <file>\n")
+        sys.exit(2)
+
+    rules = set(r.strip() for r in args.rules.split(",") if r.strip()) if args.rules else None
+
+    findings, stats = scan_tree(
+        args.root,
+        excludes=args.exclude,
+        rules=rules,
+        project_checks=not args.no_project_checks,
+    )
+
+    baseline = None
+    if args.baseline and os.path.exists(args.baseline):
+        try:
+            baseline = load_baseline(args.baseline)
+        except (OSError, ValueError) as exc:
+            sys.stderr.write("baseline read/parse error: %s\n" % exc)
+            sys.exit(2)
+    elif args.baseline and not args.update_baseline:
+        # A missing baseline must never read as "nothing known, nothing new".
+        sys.stderr.write(
+            "baseline not found: %s — create it with --update-baseline (and commit it)\n" % args.baseline
+        )
+        sys.exit(2)
+
+    new_keys = set()
+    if baseline is not None:
+        known = set(baseline.get("findings", []))
+        new_keys = set(f["key"] for f in findings) - known
+    else:
+        new_keys = set(f["key"] for f in findings)
+
+    if args.update_baseline:
+        new_base = build_baseline(findings, stats)
+        if baseline is not None and not args.allow_baseline_growth:
+            before = baseline_error_count(baseline)
+            after = baseline_error_count(new_base)
+            if after > before:
+                sys.stderr.write(
+                    "refusing to grow the baseline: errors %d -> %d. Fix the new violations, or pass "
+                    "--allow-baseline-growth with a written reason in the PR.\n" % (before, after)
+                )
+                sys.exit(1)
+        with open(args.baseline, "w", encoding="utf-8") as fh:
+            json.dump(new_base, fh, ensure_ascii=False, indent=2, sort_keys=True)
+            fh.write("\n")
+        print("baseline written: %s (error=%d warn=%d, from %d files)"
+              % (args.baseline, new_base["counts"][ERROR], new_base["counts"][WARN], stats["files_scanned"]))
+        if stats["files_scanned"] == 0:
+            sys.stderr.write("UNKNOWN: 走査対象 0 件 — baseline を空で固定してはいけない（--root を確認）\n")
+            sys.exit(3)
+        sys.exit(0)
+
+    if args.format == "json":
+        print(json.dumps({
+            "root": args.root,
+            "stats": stats,
+            "baseline": None if baseline is None else {"known": len(baseline.get("findings", []))},
+            "findings": findings,
+            "new": sorted(new_keys),
+        }, ensure_ascii=False, indent=2))
+    else:
+        print(format_text_report(args.root, findings, stats, new_keys, baseline, args.strict))
+
+    # "Zero files scanned" is UNKNOWN, never a pass (empty output != zero findings).
+    if stats["files_scanned"] == 0:
+        sys.exit(3)
+
+    fatal = [f for f in findings if f["key"] in new_keys and (f["severity"] == ERROR or args.strict)]
+    sys.exit(1 if fatal else 0)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/check_sync.py
+++ b/scripts/check_sync.py
@@ -277,7 +277,24 @@ def validate_codex_build_skill() -> list[str]:
             errors.append(f"codex-build skill must reference shared project path {shared_path}")
     if "explicit" not in text.lower() or "subagent" not in text.lower():
         errors.append("codex-build skill must state that Codex subagents require explicit user authorization")
+    errors.extend(_validate_a11y_wiring("codex-build", text))
 
+    return errors
+
+
+def _validate_a11y_wiring(skill_name: str, text: str) -> list[str]:
+    """Adapters mirror the canonical /build flow, so they must carry the a11y wiring too.
+
+    Without this, a Codex or Antigravity session would run the same 5 phases while quietly
+    dropping the accessibility contract — the platforms would drift on the one dimension
+    whose failures are invisible in the diff.
+    """
+    errors: list[str] = []
+    lowered = text.lower()
+    if "a11y-standards" not in lowered:
+        errors.append(f"{skill_name} skill must point at skills/a11y-standards for UI work")
+    if "a11y-static-check.py" not in lowered:
+        errors.append(f"{skill_name} skill must run the a11y static gate on UI diffs")
     return errors
 
 
@@ -302,6 +319,7 @@ def validate_antigravity_build_skill() -> list[str]:
         errors.append("antigravity-build skill must reference Planning Mode")
     if "define_subagent" not in text.lower():
         errors.append("antigravity-build skill must reference define_subagent")
+    errors.extend(_validate_a11y_wiring("antigravity-build", text))
 
     return errors
 

--- a/scripts/test/test_a11y_static_gate.sh
+++ b/scripts/test/test_a11y_static_gate.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+# Locks the a11y static gate. Two regression classes live here:
+#
+#   1. The gate's own truth table (its hermetic --self-test): name/role/state
+#      detection per stack, the ratchet (baseline suppresses known, catches new),
+#      the anti-gaming refusal to grow a baseline, and "zero files scanned =
+#      UNKNOWN, not zero violations".
+#   2. The false-positive fixtures found while validating against real repos
+#      (implicit <label> wrapping, JSX inside template literals, monorepo lint
+#      configs, PHP themes with a build package.json). A gate that cries wolf
+#      gets switched off, so those stay locked too — they are part of --self-test.
+#
+# Also asserts the boundary the gate must never cross: it inspects and reports,
+# it never edits code and never wires itself into CI.
+# shellcheck source=scripts/test/lib.sh
+source "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+S="$KIT_ROOT/scripts"
+GATE="$S/a11y-static-check.py"
+
+assert_file_exists "$GATE"
+assert_cmd_ok "python3 -c 'import ast,sys; ast.parse(open(sys.argv[1]).read())' '$GATE'" \
+  "a11y-static-check.py parses as valid python"
+assert_cmd_ok "python3 '$GATE' --self-test" "a11y-static-check.py --self-test passes"
+
+# Exit-code contract: a missing --root is a usage error (2), never a silent pass.
+out="$(python3 "$GATE" 2>&1)"; rc=$?
+assert_eq "$rc" "2" "no --root => exit 2 (usage error)"
+
+# "Zero scannable files" must be UNKNOWN (3), not "clean" (0) — the empty-output-is-not-zero rule.
+tmp="$(mktemp -d)"
+python3 "$GATE" --root "$tmp" >/dev/null 2>&1; rc=$?
+assert_eq "$rc" "3" "empty tree => exit 3 UNKNOWN (not 0)"
+
+# A violation fails; the same tree with a baseline passes; a NEW violation fails again.
+mkdir -p "$tmp/lib"
+cat > "$tmp/lib/bad.dart" <<'DART'
+class Bad extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) =>
+      GestureDetector(onTap: go, child: const Icon(Icons.book));
+}
+DART
+python3 "$GATE" --root "$tmp" --no-project-checks >/dev/null 2>&1; rc=$?
+assert_eq "$rc" "1" "unlabelled tap target => exit 1"
+
+python3 "$GATE" --root "$tmp" --no-project-checks --baseline "$tmp/base.json" --update-baseline >/dev/null 2>&1
+assert_file_exists "$tmp/base.json" "--update-baseline writes the snapshot"
+python3 "$GATE" --root "$tmp" --no-project-checks --baseline "$tmp/base.json" >/dev/null 2>&1; rc=$?
+assert_eq "$rc" "0" "baselined violation => exit 0 (ratchet)"
+
+cat > "$tmp/lib/more.dart" <<'DART'
+class More extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) =>
+      GestureDetector(onTap: go, child: const Icon(Icons.add));
+}
+DART
+python3 "$GATE" --root "$tmp" --no-project-checks --baseline "$tmp/base.json" >/dev/null 2>&1; rc=$?
+assert_eq "$rc" "1" "NEW violation on top of a baseline => exit 1"
+
+# Anti-gaming: the baseline may shrink, never grow silently.
+python3 "$GATE" --root "$tmp" --no-project-checks --baseline "$tmp/base.json" --update-baseline >/dev/null 2>&1; rc=$?
+assert_eq "$rc" "1" "growing the baseline is refused without --allow-baseline-growth"
+python3 "$GATE" --root "$tmp" --no-project-checks --baseline "$tmp/base.json" --update-baseline --allow-baseline-growth >/dev/null 2>&1; rc=$?
+assert_eq "$rc" "0" "growth allowed only with the explicit flag"
+
+# A referenced-but-missing baseline is an error (2), never "nothing known, nothing new".
+python3 "$GATE" --root "$tmp" --no-project-checks --baseline "$tmp/nope.json" >/dev/null 2>&1; rc=$?
+assert_eq "$rc" "2" "missing baseline => exit 2 (never fail-open)"
+
+# json output stays machine-readable
+python3 "$GATE" --root "$tmp" --no-project-checks --format json > "$tmp/out.json" 2>/dev/null
+assert_cmd_ok "python3 -c 'import json,sys; d=json.load(open(sys.argv[1])); assert d[\"findings\"] and d[\"stats\"][\"files_scanned\"]>0' '$tmp/out.json'" \
+  "--format json emits findings + scan denominators"
+
+rm -rf "$tmp"
+
+# Boundary locks (verbatim): detection only, and it never self-installs into CI.
+assert_contains "$GATE" "DETECTION ONLY" "gate documents that it never edits code"
+assert_contains "$GATE" "Never installs itself into CI" "gate documents that CI wiring stays a human decision"
+assert_not_contains "$GATE" "subprocess" "gate shells out to nothing (no gh/aws/git dependency)"
+
+# The skill + adoption examples ship with it.
+assert_file_exists "$KIT_ROOT/skills/a11y-static-gate/SKILL.md"
+assert_file_exists "$KIT_ROOT/skills/a11y-standards/SKILL.md"
+assert_file_exists "$KIT_ROOT/examples/a11y/a11y-baseline.example.json"
+assert_file_exists "$KIT_ROOT/examples/a11y/flutter/a11y_smoke_test.dart"
+assert_file_exists "$KIT_ROOT/examples/a11y/web/eslint-a11y.config.md"
+assert_file_exists "$KIT_ROOT/examples/ci/a11y-gate-pattern.md"
+
+t_summary

--- a/scripts/test/test_agent_guards.sh
+++ b/scripts/test/test_agent_guards.sh
@@ -22,4 +22,16 @@ assert_contains "$AG/dev-reviewer.md" 'Review the FULL diff before marking PASS'
 assert_contains "$AG/dev-explorer.md" 'No nested subagents' \
   "dev-explorer keeps the no-nested-subagents guard"
 
+# a11y role contracts. The severity phrasing in dev-reviewer is the load-bearing part:
+# a missing accessible name reported as LOW gets deferred forever.
+assert_contains "$AG/dev-planner.md"  '## A11y plan' \
+  "dev-planner keeps the a11y plan section in its output contract"
+assert_contains "$AG/dev-reviewer.md" 'Treat a missing name or role as CRITICAL, not LOW' \
+  "dev-reviewer keeps the a11y severity guard"
+assert_contains "$AG/dev-tester.md"   'a11y-static-check.py' \
+  "dev-tester keeps the a11y gate in its run set"
+for a in dev-planner dev-reviewer; do
+  assert_grep "$AG/$a.md" '^  - a11y-standards$' "$a preloads a11y-standards"
+done
+
 t_summary

--- a/scripts/test/test_build_guards.sh
+++ b/scripts/test/test_build_guards.sh
@@ -24,4 +24,14 @@ assert_contains "$BUILD" 'Phase 3/5 を subagent 化しない' \
 assert_contains "$BUILD" '4 agent に厳選（追加禁止）' \
   "/build keeps the options-flooding guard (4 agents, no additions)"
 
+# a11y is a design-time decision, not a post-hoc audit. If these drop out of /build, the
+# kit silently returns to "accessibility gets added later" — the failure mode that produced
+# a whole app of unnamed controls.
+assert_contains "$BUILD" 'a11y を計画段階で決める' \
+  "/build keeps a11y in Phase 2 (designed, not retrofitted)"
+assert_contains "$BUILD" 'scripts/a11y-static-check.py' \
+  "/build keeps the a11y gate in Phase 4 verification"
+assert_contains "$BUILD" 'a11y の後付け' \
+  "/build keeps a11y-retrofit in the failure-mode list"
+
 t_summary

--- a/scripts/test/test_structure.sh
+++ b/scripts/test/test_structure.sh
@@ -16,6 +16,16 @@ assert_file_exists "$KIT_ROOT/skills/dev-standards/SKILL.md"
 assert_file_exists "$KIT_ROOT/skills/codex-build/SKILL.md"
 assert_file_exists "$KIT_ROOT/skills/antigravity-build/SKILL.md"
 
+# a11y: the design-time contract, the deterministic gate, and the runtime templates.
+# All three are referenced from dev-standards / build.md / the agents, so a missing one
+# turns the a11y wiring into dangling references.
+assert_file_exists "$KIT_ROOT/skills/a11y-standards/SKILL.md"
+assert_file_exists "$KIT_ROOT/skills/a11y-static-gate/SKILL.md"
+assert_file_exists "$KIT_ROOT/scripts/a11y-static-check.py"
+assert_file_exists "$KIT_ROOT/examples/a11y/flutter/a11y_smoke_test.dart"
+assert_file_exists "$KIT_ROOT/examples/a11y/web/eslint-a11y.config.md"
+assert_file_exists "$KIT_ROOT/docs/a11y-guide.md"
+
 # downstream extension scaffold (consumers copy this into project-standards/)
 assert_file_exists "$KIT_ROOT/examples/project-standards-template/SKILL.md"
 

--- a/skills/a11y-standards/SKILL.md
+++ b/skills/a11y-standards/SKILL.md
@@ -1,0 +1,169 @@
+---
+name: a11y-standards
+description: UI を作る/変える全変更に適用するアクセシビリティ標準。accessible name / role / state の三点セット + 文字拡大 + コントラスト + ターゲットサイズ + キーボードを、Flutter / React(Next.js) / WordPress(PHP) のイディオムと検証手段（決定論ゲート・自動テスト・人手）に落とす。Triggers: accessibility, a11y, アクセシビリティ, screen reader, VoiceOver, TalkBack, semantics, ARIA, alt text, dynamic type, 文字サイズ, contrast, keyboard navigation, tap target, WCAG.
+---
+
+# a11y standards — 後付けしない前提の設計標準
+
+アクセシビリティは**実装後に監査で足すものではなく、UI を設計する時点で決めるもの**。後付けは「操作要素が全部無名」のような構造的欠陥になり、修正が全画面に散る。
+
+このスキルは UI に触る全変更に適用する。`dev-standards` から参照され、`/build` の Phase 2（計画）と Phase 4（検証）で使う。
+
+---
+
+## 1. 最小契約（10 行・スタック非依存）
+
+新規/変更した UI がこれを満たすまで実装完了としない。
+
+1. **name** — 操作要素はすべて意味のある accessible name を持つ（WCAG 2.2 SC 4.1.2 / Level A）
+2. **role** — 押せるものは「ボタン」等の役割を宣言する。見た目だけのボタンは支援技術にはボタンではない
+3. **state** — 無効・選択中・開閉・トグルは状態として公開する（見た目の色だけで表さない）
+4. **記号をラベルにしない** — `<` `×` `…` `+` は記号名で読み上げられる（`<` は「小なり」）。語を与え、記号は読み上げから外す
+5. **文字拡大 200%（iOS は AX5 ≒ 3.12x）でレイアウトが壊れない** — 固定高さに文字を詰めない（SC 1.4.4 / 1.4.10）
+6. **コントラスト** — 本文 4.5:1・大きい文字 3:1（18pt / bold 14pt 以上）・UI 部品と状態表示 3:1（SC 1.4.3 / 1.4.11）
+7. **ターゲットサイズ** — 最小 24×24 CSS px（SC 2.5.8）。モバイルは実務上 44×44（iOS）/ 48×48（Android・Flutter 公式チェックリスト）を採る
+8. **キーボードだけで完結する**（Web/デスクトップ）— フォーカスが見え（SC 2.4.7）、順序が視覚順と一致し、トラップしない
+9. **色だけで情報を伝えない**（SC 1.4.1）／**モーションは `prefers-reduced-motion` で止める**（SC 2.3.3）
+10. **主要導線 1 本は読み上げだけで通せる** — 「ログイン → 主要操作 → 完了」を音声のみで到達できること。ここが受入条件
+
+> **静的ゲートが緑 ≠ アクセシブル**。ゲートは「機械が見つけられる欠陥が無い」ことしか言わない。10 は人手でしか確認できない。
+
+### 対外的な表記の線引き（重要）
+
+自動検出でカバーできるのは違反の一部（Deque の調査で issue 件数ベース約 57%）。
+**「WCAG 2.2 AA 準拠」「アクセシブル」と書いてよいのは人手監査を経た場合だけ**で、
+受託契約・LP・ストア申告に書くのは Level 3（社長承認）。ゲートが言えるのは
+**「機械判定可能な違反ゼロ（走査 N 件）」**まで。この線を越えた表記は法的リスクになる。
+出典: https://www.deque.com/blog/automated-testing-study-identifies-57-percent-of-digital-accessibility-issues/ ・ https://www.w3.org/WAI/test-evaluate/
+
+---
+
+## 2. 設計時に決めること（Phase 2 で必ず書く）
+
+UI を追加/変更する計画には、要素ごとに次を明記する。決めずに実装に入らない。
+
+| 決めること | 書き方の例 |
+|---|---|
+| accessible name | 「日記を開く」（表示は本のアイコンのみ） |
+| role | button / link / textField / header |
+| state | enabled: `_canSend` / toggled: `notifyOn` |
+| 拡大時の振る舞い | 高さは内容に追従（固定 48 は使わない）・2 行超は省略せず折り返す |
+| 読み上げ順 | ヘッダ → 本文 → 操作。Stack で視覚順とずれる場合は `sortKey` |
+
+UI を触らない変更では「a11y: N/A（UI 非変更）」と明示する。空欄は「検討していない」と同じ。
+
+---
+
+## 3. スタック別イディオム（正解と典型的な誤り）
+
+### Flutter
+
+```dart
+// ❌ 名前も役割も無い（読み上げでは無名の要素・「ボタン」と言われない）
+GestureDetector(onTap: openDiary, child: const Icon(Icons.book))
+
+// ❌ 記号がそのままラベル（VoiceOver は「小なり」と読む）
+GestureDetector(onTap: pop, child: const Text('<'))
+
+// ❌ 文字はあるが role/state が無い（「ボタン」でも「無効」でもないと伝わる）
+GestureDetector(onTap: enabled ? onTap : null, child: Text(label))
+
+// ✅ name + role + state を 1 ノードに畳み、装飾の記号は読み上げから外す
+Semantics(
+  button: true,
+  enabled: enabled,
+  label: '戻る',
+  child: ExcludeSemantics(
+    child: GestureDetector(
+      onTap: enabled ? pop : null,
+      child: const SizedBox(width: 48, height: 48, child: Center(child: Text('<'))),
+    ),
+  ),
+)
+
+// ✅ 入力欄は必ず名前を持たせる（hintText: '' は名前ではない）
+TextField(decoration: const InputDecoration(labelText: 'メッセージ'))
+
+// ✅ アイコンボタンは tooltip が name になる（engine が accessibilityLabel に昇格させる）
+IconButton(tooltip: '共有', onPressed: share, icon: const Icon(Icons.share))
+```
+
+- **共通ボタン Widget を 1 つ用意し、生の `GestureDetector` を操作要素に使わない**。ラッパー 1 ファイルの修正が全画面に効く（逆に、ラッパーが無名だと全画面が無名になる）
+- 文字拡大のグローバル方針は `MediaQuery.withClampedTextScaling(maxScaleFactor: 2.0)` を root に 1 箇所。
+  **2.0 未満のクランプは WCAG 1.4.4（200% まで利用可能）違反**であり、Apple の「Larger Text」申告も満たせない。
+  さらに**クランプは緩和策で修正ではない**（実測: 固定高さの箱は 1.6x にクランプしても 16px 溢れた）
+- `textScaleFactor` 系 API は deprecated。`MediaQuery.textScalerOf(context).scale(fontSize)` を使う
+
+### React / Next.js
+
+```tsx
+// ❌ div にクリック（キーボード・支援技術から操作不能）
+<div onClick={save}>保存</div>
+// ❌ アイコンのみのボタン / alt 無し画像 / 記号ラベル
+<button onClick={close}><XIcon /></button>
+<img src="/hero.png" />
+<a href="/next">×</a>
+
+// ✅ 素の HTML 要素に戻すのが最短の正解
+<button type="button" onClick={save}>保存</button>
+<button type="button" aria-label="閉じる" onClick={close}><XIcon aria-hidden="true" /></button>
+<img src="/hero.png" alt="海に沈む夕日" />   {/* 装飾なら alt="" を明示 */}
+<label htmlFor="q">検索</label><input id="q" type="search" />
+```
+
+- `role`/`tabIndex`/`onKeyDown` を手で足すのは、素の `button`/`a` が使えない時だけ
+- placeholder はラベルの代替にならない（入力すると消える）
+- ダークモードは**別テーマとして**コントラストを検証する（片側だけ落ちるのが典型）
+
+### WordPress / PHP
+
+```php
+<?php // ❌ alt 無し・空リンク・ラベル無しフォーム ?>
+<img src="<?php echo esc_url( $url ); ?>">
+<a href="#"></a>
+<input type="search" name="s">
+
+<?php // ✅ ?>
+<img src="<?php echo esc_url( $url ); ?>" alt="<?php echo esc_attr( $alt ); ?>">
+<a href="<?php echo esc_url( $link ); ?>"><?php echo esc_html( $title ); ?></a>
+<label for="s">サイト内検索</label><input type="search" id="s" name="s">
+```
+
+- **skip link**（最初の focusable・focus で可視化）／landmark（`<main>` `<nav>`）／`<h1>` は 1 ページ 1 つ・見出しレベルを飛ばさない
+- viewport で拡大を禁止しない（`user-scalable=no` / `maximum-scale<2` は 1 行で全ページを壊す）
+- 正の `tabindex` を使わない（0 と -1 のみ）
+- 本文中リンクは下線を付ける（色だけの区別は不可）。`read more` のような文脈依存リンクテキストを避ける
+- WordPress.org の `accessibility-ready` タグを謳う場合は 18 要件 + テーマルートの `accessibility.txt` が要件（→ `docs/a11y-guide.md`）
+
+---
+
+## 4. 検証の三段（下に行くほど強いが自動化できない）
+
+| 段 | 何を保証するか | 手段 |
+|---|---|---|
+| **静的ゲート**（毎コミット） | name/role/state・記号ラベル・alt・拡大禁止・正 tabindex の**構文的**欠落ゼロ | `a11y-static-gate`（`scripts/a11y-static-check.py`・exit code） |
+| **自動テスト**（CI） | 実際に描画された結果での役割・ラベル・タップサイズ・コントラスト・**最大文字サイズでの崩れ**・読み上げ順 | Flutter: `examples/a11y/flutter/a11y_smoke_test.dart`（組込 4 ガイドライン + role/記号ラベルの自作ガイドライン + AX5/200% の overflow 検査）/ Web: `eslint-plugin-jsx-a11y` + axe-core（`examples/a11y/web/eslint-a11y.config.md`） |
+| **人手・実機**（リリース前） | 読み上げだけで主要導線が通るか・ラベルが**理解できる**か・拡大時に読めるか | VoiceOver / TalkBack で通し操作、最大文字サイズでスクリーンショット確認 |
+
+**Flutter の重要な穴（実測・Flutter 3.44.2）**: 組込の `labeledTapTargetGuideline` は **role を見ず**、`Text('<')` も**非空ラベルとして通す**。つまり「ラベルはあるが役割が無い」「記号がラベル」の 2 つは組込ガイドラインでは緑になる。kit はこの 2 つを静的ゲート（`A11Y-FLUTTER-ROLE` / `A11Y-FLUTTER-SYMBOL-LABEL`）と自作ガイドライン（`ButtonRoleGuideline` / `MeaningfulLabelGuideline`）の両方で塞ぐ。
+
+---
+
+## 5. 自動化できないもの（ここを人手に残すと決める）
+
+- 読み上げだけで主要導線が完了できるか（実機 VoiceOver / TalkBack）
+- ラベルが理解できる語か（`戻る` が適切かは機械には判断できない・日本語の読み上げ品質も OS の TTS 依存）
+- 画像・グラデーション上の文字のコントラスト
+- 拡大時に「読める」か（overflow ゼロ ≠ 読みやすい）
+- 視覚順と読み上げ順のずれが実際に混乱を生むか
+
+---
+
+## 6. 参照
+
+- WCAG 2.2（W3C Recommendation・2024-12-12）: https://www.w3.org/TR/WCAG22/
+- ネイティブアプリへの適用（WCAG2ICT）: https://www.w3.org/TR/wcag2ict-22/
+- Flutter accessibility / testing: https://docs.flutter.dev/ui/accessibility ・ https://docs.flutter.dev/ui/accessibility/accessibility-testing
+- Apple VoiceOver / Larger Text の評価基準（App Store の Accessibility Nutrition Labels）: https://developer.apple.com/help/app-store-connect/manage-app-accessibility/overview-of-accessibility-nutrition-labels
+- WordPress Accessibility Ready 要件: https://wpaccessibility.org/docs/accessibility-ready/theme-guidelines/
+- 導入手順・レガシー repo への段階適用・事業/法令の背景: [`docs/a11y-guide.md`](../../docs/a11y-guide.md)

--- a/skills/a11y-static-gate/SKILL.md
+++ b/skills/a11y-static-gate/SKILL.md
@@ -1,0 +1,104 @@
+---
+name: a11y-static-gate
+description: Read-only deterministic gate that fails a build when an interactive element has no accessible name / role / state — across Flutter (.dart), React (.tsx/.jsx) and PHP/HTML templates. Structure-aware (ancestor chain, not line windows), with a baseline + ratchet so a legacy repo can adopt it without a rewrite, and an anti-gaming refusal to grow the baseline. Triggers: a11y gate, accessibility gate, アクセシビリティ ゲート, semantics 欠落, accessible name, button role, alt 欠落, 記号ラベル, a11y baseline, ratchet.
+---
+
+# a11y-static-gate
+
+`${CLAUDE_PLUGIN_ROOT:-.}/scripts/a11y-static-check.py` は、コードツリーを走査して
+**「支援技術から操作できない UI 要素」** を決定論的に検出する。
+
+「ちゃんとラベルを付けて」という指示は確率的だが、exit code は確率的でない。
+
+## 何を見るか
+
+構造（括弧/タグのスタックと祖先チェーン）を解析するので、「この tappable を包む祖先に
+ラベルがあるか」に正しく答えられる。行ウィンドウの grep はこれを両方向に間違える。
+
+| rule | severity | 検出内容 |
+|---|---|---|
+| `A11Y-FLUTTER-NAME` | error | `GestureDetector`/`InkWell`/`IconButton` 等に tap があるが名前が無い |
+| `A11Y-FLUTTER-ROLE` | error | ラベルはあるが `Semantics(button: true)` が無い自作ボタン |
+| `A11Y-FLUTTER-SYMBOL-LABEL` | error | ラベルが記号のみ（`<` `×` `•••`）＝記号名で読み上げられる |
+| `A11Y-FLUTTER-STATE` | warn | 条件付きコールバックなのに `Semantics(enabled:)` が無い |
+| `A11Y-FLUTTER-FIELD-NAME` | error | `TextField` に名前が無い（`hintText: ''` は名前ではない） |
+| `A11Y-FLUTTER-TOGGLE-NAME` | error | `Switch`/`Checkbox` に名前が無い |
+| `A11Y-FLUTTER-IMAGE-LABEL` | warn | `Image` に `semanticLabel` も `excludeFromSemantics` も無い |
+| `A11Y-WEB-INTERACTIVE-DIV` | error | `div`/`span` に click があるが role/tabIndex/キーボード処理が無い |
+| `A11Y-WEB-CONTROL-NAME` | error | `button`/`a` に名前が無い（アイコンのみ） |
+| `A11Y-WEB-SYMBOL-LABEL` | error | `button`/`a` のラベルが記号のみ |
+| `A11Y-WEB-IMG-ALT` / `A11Y-MARKUP-IMG-ALT` | error | `img` に `alt` が無い（`alt=""` は装飾として許容） |
+| `A11Y-WEB-FIELD-NAME` / `A11Y-MARKUP-FIELD-NAME` | error | 入力要素に label 関連付けも `aria-label` も無い |
+| `A11Y-WEB-FIELD-LABEL-UNVERIFIED` | warn | `id` はあるが対応する `<label for>` を静的に確認できない |
+| `A11Y-*-VIEWPORT-ZOOM` | error | `user-scalable=no` / `maximum-scale<2`（拡大禁止） |
+| `A11Y-*-POSITIVE-TABINDEX` | error | 正の `tabindex`（タブ順が DOM 順から乖離） |
+| `A11Y-PROJ-SCALE-TEST` | warn | 最大文字サイズを再現する自動テストが無い（Flutter repo） |
+| `A11Y-PROJ-WEB-LINT` / `-SUBSET` | warn | a11y linter 未設定 / Next.js 既定の部分適用のみ |
+
+## Boundary（read-only）
+
+- **検出のみ**。`Semantics` を挿入したりコードを書き換えたりしない。修正は人（と PR）の仕事
+- **自分を CI に配線しない**。required status check / branch protection 化は self-lockout 側のリスクを持つ変更なので、人が意図して行う（→ [`examples/ci/a11y-gate-pattern.md`](../../examples/ci/a11y-gate-pattern.md)）
+- **gh / aws / git を呼ばない**。ローカルのファイル読取だけ・python3 stdlib のみ
+- **静的解析はアクセシビリティを証明しない**。緑は「機械が見つけられる命名/役割の欠陥が無い」だけ。読み上げでの通し操作と拡大時のレイアウトは `a11y-standards` の自動テストと実機確認が担う
+
+## 使い方
+
+```bash
+# 単発（新規プロジェクト・違反 0 が前提）
+python3 "${CLAUDE_PLUGIN_ROOT:-.}/scripts/a11y-static-check.py" --root .
+
+# 既存 repo（違反が既にある）: 現状を凍結して以後の新規違反だけ落とす
+python3 "${CLAUDE_PLUGIN_ROOT:-.}/scripts/a11y-static-check.py" --root . \
+    --baseline .a11y-baseline.json --update-baseline   # 初回のみ
+python3 "${CLAUDE_PLUGIN_ROOT:-.}/scripts/a11y-static-check.py" --root . \
+    --baseline .a11y-baseline.json                     # 以後（CI）
+```
+
+主なオプション: `--strict`（warn も落とす）/ `--format json` / `--rules <ID,...>` /
+`--exclude <substr>`（repeatable）/ `--no-project-checks`。
+
+**exit code**: `0` 新規違反なし / `1` 新規違反あり / `2` 引数・baseline 読取エラー
+（**baseline を指定して不在なら 2** — 「既知ゼロ・新規ゼロ」に倒さない）/
+`3` **UNKNOWN = 走査対象 0 件**（クリーンではなく `--root`/`--exclude` の誤り）。
+
+出力は必ず**分母**を伴う（走査ファイル数・拡張子別・検査した操作要素数・rule 別件数・
+件数の多いファイル上位）。「0 件」だけを出して走査 0 件と区別できない状態にしない。
+
+## baseline と ratchet（レガシー導入の要）
+
+- fingerprint は **内容ベース**（rule + file + 正規化スニペット + 出現順）。行がずれても
+  新規違反として再発火しない
+- `--update-baseline` は**件数が増える更新を拒否**する。増やすには
+  `--allow-baseline-growth` が必要で、その痕跡が diff と PR に残る
+  （`coverage-floor-lock` の「floor を下げる diff 自体が違反」と同じ規律）
+- 修正後に `--update-baseline` で fixed エントリを刈る。`counts.error` は単調減少が期待値
+
+## 誤検出への対処（除外より抑制を選ぶ）
+
+```dart
+// a11y-ignore: 装飾のヒット領域で、同じ操作を上のボタンが提供している
+GestureDetector(onTap: noop, child: const Icon(Icons.circle))
+```
+
+理由付きの `a11y-ignore: <理由>` のみが抑制する。**理由の無い裸の `a11y-ignore` は抑制せず、
+件数として報告される**。ファイル単位の `--exclude` で黙らせるより、1 行の理由を残す。
+
+## Deterministic --check（self-test）
+
+```bash
+python3 "${CLAUDE_PLUGIN_ROOT:-.}/scripts/a11y-static-check.py" --self-test
+```
+
+hermetic（`mktemp` の fixture のみ・repo に何も書かない）。各スタックの検出/非検出、
+ratchet、baseline 成長拒否、走査 0 件 = UNKNOWN、抑制 pragma、そして**実 repo で見つかった
+偽陽性の再発ロック**（`<label>` の暗黙関連付け・テンプレートリテラル内の JSX コード例・
+monorepo の lint 設定・build 用 package.json を持つ PHP テーマ）を検査する。
+期待値を 1 つ変えれば FAIL する（成功のハードコードなし）。
+
+## Related
+
+- 設計標準（何を守るか）: [`a11y-standards`](../a11y-standards/)
+- 実行時テストの雛形: [`examples/a11y/flutter/a11y_smoke_test.dart`](../../examples/a11y/flutter/a11y_smoke_test.dart) / [`examples/a11y/web/eslint-a11y.config.md`](../../examples/a11y/web/eslint-a11y.config.md)
+- CI 配線と ratchet 運用: [`examples/ci/a11y-gate-pattern.md`](../../examples/ci/a11y-gate-pattern.md)
+- 同じ族のゲート: [`coverage-floor-lock`](../coverage-floor-lock/)（下限ロック）・[`architecture-parity-gate`](../architecture-parity-gate/)（構造違反）

--- a/skills/antigravity-build/SKILL.md
+++ b/skills/antigravity-build/SKILL.md
@@ -28,7 +28,8 @@ Claude Code のロール契約（`agents/` 配下）で指定されているツ�
 
 開発開始時および検証時に、以下のファイルを必ず読み込んでください。
 
-- 共通開発標準: [skills/dev-standards/SKILL.md](file:///Users/yutaroshirai/GitHub/willink-claude-kit/skills/dev-standards/SKILL.md)
+- 共通開発標準: [skills/dev-standards/SKILL.md](../dev-standards/SKILL.md)
+- UI を触る場合の a11y 標準: [skills/a11y-standards/SKILL.md](../a11y-standards/SKILL.md)
 - プロジェクト固有標準（存在する場合）: `.claude/skills/project-standards/SKILL.md`
 - レビュー用メモリ（存在する場合）: `.claude/agent-memory/dev-reviewer/MEMORY.md`
 
@@ -45,6 +46,7 @@ Claude Code のロール契約（`agents/` 配下）で指定されているツ�
 
 ### Phase 2: 実装計画
 - **起動条件**: 変更が50行以上または複数ファイルにまたがる場合に実行。軽微な修正はスキップします。
+- **UI を触る場合**: `implementation_plan.md` に、新規/変更する操作要素ごとの accessible name / role / state と、文字拡大 200% 時のレイアウト方針を明記します（a11y は実装後の監査ではなく計画事項）。UI 非変更なら「a11y: N/A」と書きます。
 - **Antigravityでの実行方法**:
   - Antigravity の標準機能である `implementation_plan.md` アーティファクトのライフサイクルに統合します。
   - 設計上の不確実性が高い場合は、 `define_subagent` で `dev-planner` を定義・起動し、計画のドラフトを作成させます。
@@ -61,6 +63,7 @@ Claude Code のロール契約（`agents/` 配下）で指定されているツ�
   - `dev-tester` には `enable_write_tools = true` を設定してテストコマンドの実行を許可し、 `dev-reviewer` には `enable_write_tools = false`（Read-only）を設定します。
   - `invoke_subagent` で両者を並行起動します。
   - **Early Victory の防止**: `dev-tester` には必ずフルテストスイートを実行させ、一部が通っただけで PASS と報告させないようにします。 `dev-reviewer` には差分のあるすべてのファイルを確認させます。
+  - **UI 差分の a11y 検証**: `dev-tester` に a11y 静的ゲート（`python3 scripts/a11y-static-check.py --root .`）と a11y テストを実行させます。**exit 3 は「走査 0 件 = 不明」で合格ではありません**。`dev-reviewer` は accessible name / role の欠落を CRITICAL として扱います。
 
 ### Phase 5: 修正 + コミット
 - **Antigravityでの実行方法**:

--- a/skills/codex-build/SKILL.md
+++ b/skills/codex-build/SKILL.md
@@ -10,6 +10,8 @@ This skill adapts the canonical Claude Code `/build` flow in `commands/build.md`
 ## Canonical Inputs
 
 - Read `skills/dev-standards/SKILL.md` before starting substantial work.
+- If the task touches UI, also read `skills/a11y-standards/SKILL.md`. Accessibility is decided in Phase 2, not
+  audited afterwards.
 - If present in a downstream repository, read `.claude/skills/project-standards/SKILL.md` for project-specific conventions. Do not create a separate Codex copy.
 - If reviewing a diff in a downstream repository, read `.claude/agent-memory/dev-reviewer/MEMORY.md` when present. Keep that Claude path as shared project memory.
 - Treat `commands/build.md` and the four Claude role contracts in `agents/` as canonical:
@@ -45,6 +47,10 @@ Codex mapping:
 
 The plan must identify files to change, existing utilities to reuse, implementation steps, tests, and rollback path.
 
+For UI work the plan must also state, per new/changed interactive element, its accessible name, role and state,
+plus how the layout behaves at 200% text. Write "a11y: N/A (no UI change)" when it does not apply — a blank
+section reads as "not considered".
+
 ## Phase 3: Implementation
 
 The main Codex agent implements the change. Do not delegate sequential implementation to another agent.
@@ -66,11 +72,15 @@ Codex mapping:
 Tester behavior:
 - Detect the stack from repo files.
 - Run all configured quality gates, even when an earlier command fails.
+- For UI diffs, also run the a11y static gate
+  (`python3 scripts/a11y-static-check.py --root . [--baseline .a11y-baseline.json]`) and the project's a11y
+  tests. Exit 3 means zero files were scanned — that is UNKNOWN, never a pass.
 - Report PASS, PARTIAL, or FAIL with commands run, failures, skipped tests, and suggested fix scope.
 
 Reviewer behavior:
 - Read the full diff and changed files in context.
-- Check spec adherence, code quality, error handling, security, tests, standards, and scope discipline.
+- Check spec adherence, code quality, error handling, security, accessibility, tests, standards, and scope
+  discipline. On UI diffs, a missing accessible name or role is CRITICAL, not a nitpick.
 - Report PASS, CONDITIONAL, or FAIL. PASS only when the reviewer would merge it.
 
 ## Phase 5: Fixes And Commit

--- a/skills/dev-standards/SKILL.md
+++ b/skills/dev-standards/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: dev-standards
-description: i-Willink 共通開発標準。スタック非依存の汎用層（TypeScript strict / Conventional Commits / OWASP / テスト方針 / コミット粒度）。各 agent が起動時に preload する。プロジェクト固有の規約は `project-standards` skill 側に書く。
+description: i-Willink 共通開発標準。スタック非依存の汎用層（TypeScript strict / Conventional Commits / OWASP / アクセシビリティ / テスト方針 / コミット粒度）。各 agent が起動時に preload する。プロジェクト固有の規約は `project-standards` skill 側に書く。
 ---
 
 # i-Willink Dev Standards (stack-agnostic)
@@ -42,7 +42,22 @@ description: i-Willink 共通開発標準。スタック非依存の汎用層（
 
 ---
 
-## 3. セキュリティ
+## 3. アクセシビリティ（UI に触る全変更に適用）
+
+**後付け禁止**。UI を追加/変更するときに設計事項として決める。後から監査で足すと「操作要素が全部無名」のような構造的欠陥になり、修正が全画面に散る。
+
+最低ライン（これを満たすまで実装完了としない）:
+
+- **name / role / state** — 操作要素はすべて accessible name を持ち、役割（button 等）と状態（無効/選択/トグル）を公開する（WCAG 2.2 SC 4.1.2）
+- **記号をラベルにしない** — `<` `×` `…` は記号名で読み上げられる（`<` は「小なり」）
+- **文字拡大 200%（iOS 最大 ≒ 3.12x）でレイアウトが壊れない** — 固定高さに文字を詰めない
+- **コントラスト** 本文 4.5:1 / 大きい文字・UI 部品 3:1、**ターゲットサイズ** 最小 24×24 CSS px（モバイルは 48）
+- **主要導線 1 本は読み上げだけで通せる** — ここが受入条件。静的ゲートが緑でも、これは人手で確認する
+
+→ スタック別の書き方・検証手段（決定論ゲート / 自動テスト / 実機）は `a11y-standards` skill。
+機械検査は `a11y-static-gate`（`scripts/a11y-static-check.py`・exit code で判定）。
+
+## 4. セキュリティ
 
 ### OWASP Top 10 を常に意識
 - **Injection**: prepared statements / parameterized queries 必須
@@ -57,7 +72,7 @@ description: i-Willink 共通開発標準。スタック非依存の汎用層（
 
 ---
 
-## 4. コミット規約
+## 5. コミット規約
 
 **Conventional Commits 必須**:
 
@@ -86,7 +101,7 @@ description: i-Willink 共通開発標準。スタック非依存の汎用層（
 
 ---
 
-## 5. PR 運用
+## 6. PR 運用
 
 - **小さく、レビューしやすく**: 500 行超は分割を真剣に検討
 - **PR description で WHY を語る**: WHAT は diff で読める
@@ -95,7 +110,7 @@ description: i-Willink 共通開発標準。スタック非依存の汎用層（
 
 ---
 
-## 6. AI 開発（Claude Code / Codex 使用時）
+## 7. AI 開発（Claude Code / Codex 使用時）
 
 - **Generator-Verifier 分離**: 実装はメイン agent（Claude Code は main Claude、Codex は main Codex）、レビューは Verifier role（dev-reviewer 相当）
 - **Telephone game 回避**: 順序的同一作業を subagent 連鎖に分割しない
@@ -106,7 +121,7 @@ description: i-Willink 共通開発標準。スタック非依存の汎用層（
 
 ---
 
-## 7. このスキルの境界
+## 8. このスキルの境界
 
 含む: 全プロジェクト共通の最低ライン
 含まない: スタック特化規約・プロジェクト固有のドメイン知識・チーム慣習


### PR DESCRIPTION
## なぜ

社内 Flutter アプリの a11y 監査で、**操作要素のほぼ全てが `GestureDetector`+`Text` の自作ボタンで button role もラベルも持たない**状態が見つかった（戻る導線は記号 `<` = 「小なり」と読まれる／アイコン導線は無名／最大文字サイズで固定寸法カードが overflow）。結論は「音声のみでの通し操作が成立しない」。

重要なのは個々のバグではなく**分布**で、共通ボタン Widget が name/role を持たないために全画面が同時に壊れていた。だから a11y は「実装後に監査で足すもの」ではなく **設計時に 1 回決めるもの**として扱う必要がある。それを kit 側の既定にする PR。

## 何を入れたか（H1 → H3 ラダーを UI 面に適用）

| 層 | 追加物 | 役割 |
|---|---|---|
| H1 契約 | `skills/a11y-standards/` | name/role/state + 拡大 + コントラスト + ターゲットサイズ + キーボードの 10 行 DoD、3 スタックの「正解と典型的な誤り」。**4 agent が preload** |
| H3 ゲート | `skills/a11y-static-gate/` + `scripts/a11y-static-check.py` | 括弧/タグのスタックと祖先チェーンを解析して「支援技術から操作できない要素」を検出。rule 20 種・stdlib のみ・**baseline + ratchet** |
| 実行時 | `examples/a11y/` | Flutter は組込 4 + **自作 2** ガイドライン + AX5/200% overflow、Web は jsx-a11y/axe/reflow |
| 配線 | `dev-standards` §3 / `/build` Phase 2・4 / 4 agent / Codex・Antigravity adapter | UI に触ると自動的に計画・レビュー・検証の対象になる |

## 実測で分かったこと（設計の根拠）

**組込ツールには構造的な穴がある** — Flutter 3.44.2 で実走して確認:

- `labeledTapTargetGuideline` は **role を見ず**、`Text('<')` も**非空ラベルとして通す** → 上の 2 大欠陥は組込ガイドラインでは**緑になる**
- Lighthouse の a11y スコアは manual 監査（`custom-controls-roles` / `logical-tab-order` 等 = まさに今回の欠陥群）を**計算に含めない** → **スコア 100 と「読み上げで操作不能」は両立する**
- axe / jsx-a11y は**アイコンのみボタンと記号ラベルを検出しない**

→ 静的ゲート（`A11Y-FLUTTER-ROLE` / `-SYMBOL-LABEL`）と自作 `AccessibilityGuideline`（`ButtonRoleGuideline` / `MeaningfulLabelGuideline`）の両方でこの 2 つを塞ぐ設計にした。

**クランプは修正ではない** — `withClampedTextScaling(maxScaleFactor: 1.6)` を挟んでも固定高さの箱は 16px 溢れた（無対策では 76px）。さらに **2.0 未満のクランプ自体が WCAG 1.4.4 違反**で Apple の Larger Text 申告も満たせないため、`A11Y-FLUTTER-SCALE-CLAMP` で数値を検査する。

**iOS 最大は 3.0x ではなく 53/17 ≒ 3.12**（engine 実測値）。3.0 でテストすると範囲上端を検査できない。

## 偽陽性を実測で潰した

社内 5 リポで走らせて偽陽性クラスを 2 つ発見・修正し、再発を self-test にロックした:

- `<label>` が `<input>` を**囲む**暗黙関連付けを違反と誤判定（有効な HTML）
- **テンプレートリテラル内の JSX コード例**を実コードとして走査
- monorepo の workspace 側 lint 設定を見落とし／build 用 `package.json` を持つ PHP テーマに JSX linter を要求

結果（error 件数）: `i-willink.com` 11 → **1**（307 tsx・残り 1 件は真の違反を目視確認）／WP テーマ **2 件・両方真の違反**（アイコンのみ `<button>`・`onclick` 付き div）／Flutter アプリは既知の監査所見を独立に再現し、**うち 1 件は監査より精密に分類**した（「ラベル欠落」ではなく「ラベルはあるが role/state 欠落」）。

## レガシー導入（ratchet）

違反が既にある repo に「違反 0」を要求するとゲートは翌日外される。現状を baseline に凍結し**新規違反のみ落とす**。fingerprint は内容ベースで行ずれに強く、**baseline を増やす更新は `--allow-baseline-growth` なしでは拒否**（`coverage-floor-lock` の「floor を下げる diff 自体が違反」と同じ規律）。抑制は**理由付き `a11y-ignore: <理由>` のみ**有効で、裸の pragma は抑制せず件数として報告される。

## 境界（意図的にやらないこと）

- **検出のみ** — コードを書き換えない、`Semantics` を挿入しない
- **CI に自己配線しない** — required check 化は self-lockout 側のリスクを持つので人が意図して行う
- **exit 3 = 走査 0 件 = UNKNOWN** — 空スキャンを「違反ゼロ」に倒さない
- **緑は「アクセシブル」と言わない** — 自動検出のカバー率は issue 件数ベースで約 57%（Deque）。「WCAG AA 準拠」表記は人手監査 + 承認が必要、という線引きを skill に明記した
- **配布は human-only** — CHANGELOG は `[Unreleased]` のみ。marketplace の `ref` は既存 tag のまま（先に version を上げると未作成 tag を指して全導入者のインストールが壊れる）

## 検証

- ゲート hermetic self-test **46 checks** PASS（各スタックの検出/非検出・ratchet・baseline 成長拒否・走査 0 件 UNKNOWN・抑制 pragma・偽陽性再発ロック）
- `scripts/test/test_a11y_static_gate.sh` **22 assertions** PASS（exit code 契約・境界の verbatim ロック）
- kit 回帰スイート **20 files ALL GREEN** / `check_sync.py --check` PASS
- Flutter 雛形を 3.44.2 で実走 — 違反 fixture を fail（role 欠落 2 / 記号ラベル / タップ 24px / overflow 254px・64px）、修正 fixture を全 pass
- **変異テストで rubber-stamp でないことを確認**: adapter の a11y 参照除去 / reviewer の severity 降格 / rule 改名 の 3 変異すべてで exit 1

## 次（この PR には含めない）

各プロダクトへの baseline 作成 + CI 配線は repo ごとの別 PR。tag/release は human-only。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YSuzeveo6BumorxBXf7Uz8