### PR TITLE
chore(release): v2.4.0 — アクセシビリティを既定で設計する 3 層

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,10 +10,10 @@
       "source": {
         "source": "url",
         "url": "https://github.com/willink-oss/willink-claude-kit.git",
-        "ref": "willink-claude-kit--v2.3.0"
+        "ref": "willink-claude-kit--v2.4.0"
       },
-      "description": "標準サブエージェント 4 本 + 5 phase /build フローを束ねた開発キット。Generator-Verifier 分離・並列探索・project-standards 拡張に対応。",
-      "version": "2.3.0",
+      "description": "標準サブエージェント 4 本 + 5 phase /build フローを束ねた開発キット。Generator-Verifier 分離・並列探索・project-standards 拡張・アクセシビリティを既定で設計する 3 層に対応。",
+      "version": "2.4.0",
       "category": "development"
     }
   ]

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "willink-claude-kit",
-  "version": "2.3.0",
+  "version": "2.4.0",
   "description": "i-Willink 標準開発エージェント基盤。dev-explorer / dev-planner / dev-tester / dev-reviewer の 4 サブエージェント + 5 phase /build コマンドを Claude Code Plugin として提供。",
   "author": {
     "name": "i-Willink合同会社",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "willink-claude-kit",
-  "version": "2.3.0",
+  "version": "2.4.0",
   "description": "i-Willink 標準開発エージェント基盤を Codex でも使うための plugin。Claude Code 版を正本にし、Codex 向け adapter skill と同期チェックを提供する。",
   "author": {
     "name": "i-Willink合同会社",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes follow [Keep a Changelog](https://keepachangelog.com/en/1.1.
 
 ## [Unreleased]
 
+## [2.4.0] - 2026-07-25
+
+**Status**: アクセシビリティを「設計時の既定」にするリリース。「a11y に配慮する」という自然言語の指示は確率的で、しかも失敗が書いた本人に見えない（見た目はボタンのままなので気づけない）。本版は契約（`a11y-standards`）と exit code（`a11y-static-gate`）に分け、UI に触る変更で自動的に計画・レビュー・検証の対象になるよう4 agent と 5 phase フローに配線する。**既存リポは baseline + ratchet で段階導入できる**（現状を凍結し新規違反のみ落とす）。既存導入者への破壊的変更はなく、更新後に `python3 scripts/a11y-static-check.py --root .` を回すところから始められる。
+
 ### Added
 - **アクセシビリティを「設計時の既定」にする 3 層** — 「a11y に配慮する」という自然言語の指示は確率的で、しかも失敗が書いた本人に見えない（見た目はボタンのままなので気づけない）。ハーネスの H1→H3 ラダーを UI 面にも適用する。
   - `skills/a11y-standards/SKILL.md`（H1・契約）— accessible name / role / state の三点セット + 文字拡大 200%（iOS AX5 ≒ 3.12x）+ コントラスト + ターゲットサイズ + キーボードを 10 行の DoD にし、Flutter / React(Next.js) / WordPress(PHP) の「正解と典型的な誤り」を対照で示す。**4 agent が preload** し、`/build` Phase 2 は UI 変更時に要素ごとの name/role/state を計画に書かせる（UI 非変更なら `a11y: N/A` を明示 — 空欄は「検討していない」と同じ）。対外的に「WCAG AA 準拠」と書ける条件（人手監査 + Level 3 承認）も線引きした。

--- a/codex/sync-manifest.json
+++ b/codex/sync-manifest.json
@@ -5,7 +5,7 @@
   "canonicalFiles": [
     {
       "path": ".claude-plugin/plugin.json",
-      "sha256": "b6e8d0c197e15db4b9ce637e42da5355b877ae51d18409b76f5901d6fc85ea80",
+      "sha256": "184d16373d76c9c6451448da020223a280012391cd35f76603842ea598a02072",
       "codexAdapters": [
         ".codex-plugin/plugin.json",
         "skills/codex-build/SKILL.md"
@@ -16,7 +16,7 @@
     },
     {
       "path": ".claude-plugin/marketplace.json",
-      "sha256": "fa7ad6e782e4e3a828713512953cc80cd432ec5c5343adb6664a36c18eed7e43",
+      "sha256": "c1db705a17a35cc719a907e9f3fd671d5cc11c5849ae8977c374c9554e1f84de",
       "codexAdapters": [
         ".codex-plugin/plugin.json",
         "skills/codex-build/SKILL.md"


### PR DESCRIPTION
## 内容

`[Unreleased]` に積まれていた #45 を **2.4.0** として確定します（社長の明示指示によるリリース）。

- `.claude-plugin/plugin.json` / `.codex-plugin/plugin.json` → `2.4.0`
- `.claude-plugin/marketplace.json` → `version: 2.4.0` / `source.ref: willink-claude-kit--v2.4.0`
- `CHANGELOG.md` → `[Unreleased]` を `[2.4.0] - 2026-07-25` に確定
- `codex/sync-manifest.json` → hash 再生成（`check_sync.py --update`）

## minor bump の理由

後方互換のまま skill 2 本（`a11y-standards` / `a11y-static-gate`）・`scripts/a11y-static-check.py`・`examples/a11y/` を追加し、既存の 4 agent と `/build` に a11y を配線したため（SemVer MINOR）。**既存導入者への破壊的変更はありません** — 更新後に `python3 scripts/a11y-static-check.py --root .` を回すところから始められます（違反が既にある repo は `--baseline … --update-baseline` で凍結）。

## 順序について

tag は**このコミットが統合された後**に打ちます。`source.ref` を先に上げると未作成 tag を指して全導入者のインストールが壊れるため、順序は逆にしません。

## 検証

- `python3 scripts/check_sync.py --check` pass
- 回帰スイート **20 files ALL GREEN**（ubuntu / macos 両マトリクス）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YSuzeveo6BumorxBXf7Uz8
