### PR TITLE
fix(cogload): partial を要約行に出す + 例示 config が silent-zero を推奨していた問題

### DIFF
--- a/examples/cogload/cogload.config.example.json
+++ b/examples/cogload/cogload.config.example.json
@@ -71,9 +71,22 @@
       "type": "command",
       "label": "Routines due",
       "lane": 3,
-      "$comment": "Generic escape hatch: counts non-empty output lines. A non-zero exit renders UNKNOWN rather than 0. Use `count_pattern` with one capture group to read a number out of the output instead, and `ok_exit_codes` when the tool signals findings with exit 1.",
+      "$comment": [
+        "Generic escape hatch: counts non-empty output lines. A non-zero exit renders UNKNOWN rather than 0.",
+        "",
+        "PREFER `count_pattern` over line counting whenever the tool prints its own total.",
+        "Counting lines breaks the moment the tool prints anything else — a footer, or a",
+        "'nothing due' notice on the empty day, which then counts as ONE item. If the tool",
+        "emits a summary line, read it with one capture group instead:",
+        "  \"count_pattern\": \"due ([0-9]+)/[0-9]+\"",
+        "",
+        "WARNING about `ok_exit_codes`: only widen it when the tool genuinely signals findings",
+        "with a non-zero exit (grep-style). If the tool always exits 0 when healthy, listing 1",
+        "as acceptable turns a CRASH into a confident '0 items' — the exact silent-zero this",
+        "dashboard exists to prevent. When unsure, leave it at [0]."
+      ],
       "cmd": ["python3", "scripts/routine-sweep.py"],
-      "ok_exit_codes": [0, 1],
+      "count_pattern": "due ([0-9]+)/[0-9]+",
       "detail": "from the routine registry"
     },
     {

--- a/scripts/cogload-dashboard.py
+++ b/scripts/cogload-dashboard.py
@@ -804,8 +804,13 @@ def main():
               f"  ({q['done_count']} resolved folded away)")
     else:
         print(f"  decision queue: not configured ({q['error']})")
+    # A partially-failed probe reports a LOWER BOUND. Dropping it from this line lets a
+    # caller copy the number out as if it were the measured total.
+    partial = [p["id"] for p in snap["probes"] if p["status"] == "partial"]
     print(f"  probes: {len(snap['probes']) - len(unknown)}/{len(snap['probes'])} measured"
           + (f", unknown: {', '.join(unknown)}" if unknown else ""))
+    if partial:
+        print(f"  ! partial: {', '.join(partial)} — these values are lower bounds, not totals")
     print(f"  {html_path}\n  {snap_path}")
 
     measured_anything = q["configured"] or any(p["status"] != "unknown" for p in snap["probes"])

--- a/scripts/test/test_cogload_dashboard.sh
+++ b/scripts/test/test_cogload_dashboard.sh
@@ -58,4 +58,15 @@ assert_grep "$TMP/out2/dashboard.html" "unknown" "an unmeasurable probe renders 
 assert_not_contains "$TMP/out2/dashboard.html" '<span class="num">0</span>' \
   "an unmeasurable probe never renders as 0"
 
+# A crashing command must not read as "0 items". The example config is the only place the
+# probe schema is documented, so it must not model the silent-zero it warns against.
+assert_not_contains "$KIT_ROOT/examples/cogload/cogload.config.example.json" '"ok_exit_codes": [0, 1]' \
+  "the example config does not widen ok_exit_codes without cause"
+assert_grep "$KIT_ROOT/examples/cogload/cogload.config.example.json" "count_pattern" \
+  "the example config reads the tool's own total instead of counting lines"
+
+# Publishing internal state from an unattended run is the failure this warns about.
+assert_grep "$KIT_ROOT/skills/cogload-dashboard/SKILL.md" "Never publish from an unattended run" \
+  "the skill warns against publishing from scheduled runs"
+
 t_summary

--- a/skills/cogload-dashboard/SKILL.md
+++ b/skills/cogload-dashboard/SKILL.md
@@ -58,9 +58,24 @@ python3 scripts/cogload-dashboard.py --self-test     # hermetic, 29 checks
 | 2 | usage or configuration error |
 | 3 | **nothing could be measured** — distinct from 0 so a caller never reads "measured nothing" as "all clear" |
 
-The HTML is self-contained (no external fonts, scripts or images) so it can be
-published as an artifact or opened from disk. It is a **snapshot**: the page states
-its own measurement time and claims nothing about the moment you read it.
+The HTML is self-contained (no external fonts, scripts or images) so it can be opened
+from disk or published. It is a **snapshot**: the page states its own measurement time
+and claims nothing about the moment you read it.
+
+### Before you publish it anywhere
+
+The page renders whatever your decision queue contains — which in practice means
+client names, contract values, unresolved vulnerability counts, and internal paths.
+Treat publishing as a decision, not a step:
+
+- **Never publish from an unattended run** (a scheduled job, a cron, a routine). If you
+  wire this into a scheduler, leave publishing out of the job entirely.
+- Publish only from an interactive session, deliberately, with the person who owns the
+  data present.
+- A published page keeps its URL only when the **same conversation** republishes the
+  same path. Publishing the same file from a different session **mints a new URL**, so a
+  daily job would quietly accumulate copies of internal state. Pass the existing URL
+  explicitly when you mean to update one.
 
 ## Configure
 


### PR DESCRIPTION
## 経緯

crew 側で同じツールを日次ルーチンに配線し、**4 レンズで敵対監査**したところ、上流にも同型の欠陥が 2 件あった。

## 1. partial が要約行から落ちていた

`probe_github_prs` は一部の owner だけ失敗すると `status="partial"` を返すが、`main()` の要約行は `unknown` しか拾っていなかった。4 owner 中 3 つが失敗した日でも「probes: 3/3 measured」と出て、呼び出し側は**下限値を完全な実測値として転記**する。

`! partial: … — these values are lower bounds, not totals` を追加。

## 2. 例示 config が silent-zero を推奨していた

routine sweep の例で `"ok_exit_codes": [0, 1]` を無警告で示していた。対象ツールが健全時つねに 0 を返す設計なら、**これはクラッシュを確信的な「0 件」に変える** — このダッシュボードが存在する理由そのものの failure mode。

crew で実際にこれを踏んだ（sweep がクラッシュした日を「due 0 件＝全ルーチン最新」と報告する状態だった）。例示 config は probe スキーマの唯一のドキュメントなので、そこが罠を模範として示しているのは重い。

- `count_pattern` でツール自身の集計行を読む方式に差し替え
- `ok_exit_codes` を広げてよい条件（grep 型の非 0 exit）と、広げた場合の危険を `$comment` に明記
- あわせて **「集計行があるなら行数を数えるな」** も追記。行数方式は空の日にツールが出す「該当なし」の 1 行を **1 件**と数えて壊れる（crew で実際に発生）

## skill の追記

生成物には顧客名・契約金額・未解消脆弱性が入りうるため:

- **無人実行（スケジューラ・cron・routine）から publish しない**。スケジューラに組む場合は publish をジョブから外す
- URL が保たれるのは**同一会話で同じパスを再 publish したときだけ**。別セッションからは新 URL が発行されるので、日次ジョブは内部状態のコピーを静かに増やす

## 検証

- self-test **29 checks** PASS
- 回帰テスト **16 → 19 PASS**（例示 config が罠を模範にしないこと・skill の警告文の存在をロック）
- 全 **21 スイート ALL GREEN**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FtpjNJoCTbpyYeUDHw5yqw