### PR TITLE
feat(codex-imagegen): Codex CLI の image_gen を使った画像生成 skill

### DIFF
--- a/scripts/codex-imagegen.sh
+++ b/scripts/codex-imagegen.sh
@@ -1,0 +1,170 @@
+#!/bin/bash
+# codex-imagegen.sh — Codex CLI の image_gen ツールで画像を生成し、実ファイルを検品する。
+#
+# 設計方針:
+#   - 生成（非決定的・LLM）と 検品（決定論・スクリプト）を分離する。
+#   - exit 0 は「画像が出来た」ではなく「実ファイルが画像として妥当だった」を意味する（fail-closed）。
+#   - プレビューではなく **保存された実ファイル**のマジックバイトと実寸を検査する
+#     （2026-07-31 の Gemini 事例: プレビューと DL 版が乖離していた）。
+#
+# 使い方:
+#   scripts/codex-imagegen.sh --prompt "..." --out path/to/out.png [options]
+#
+# Options:
+#   --prompt <text>     生成指示（必須）
+#   --out <path>        出力ファイルパス（必須・.png / .jpg）
+#   --aspect <spec>     "1:1" / "16:9" / "4:5" など。プロンプトに添えるだけで厳密保証はしない
+#   --ref <file>        参照画像（繰り返し可・codex exec -i に渡す）
+#   --attempts <n>      検品失敗時の再試行回数（既定 2）
+#   --min-bytes <n>     最小バイト数（既定 10000・空/破損検知）
+#   --model <name>      codex のモデル（既定 gpt-5.6-sol）
+#   --effort <level>    reasoning effort（既定 low — 画像生成品質は reasoning では上がらない）
+#   --timeout <sec>     1 回あたりの上限秒（既定 300）
+#
+# Exit codes:
+#   0 = 生成 + 検品 pass
+#   1 = 検品 fail（試行を使い切った）
+#   2 = 使い方の誤り / codex 不在
+
+set -uo pipefail
+
+PROMPT=""
+OUT=""
+ASPECT=""
+ATTEMPTS=2
+MIN_BYTES=10000
+MODEL="gpt-5.6-sol"
+EFFORT="low"
+TIMEOUT_SEC=300
+REFS=()
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --prompt)     PROMPT="${2:-}"; shift 2 ;;
+    --out)        OUT="${2:-}"; shift 2 ;;
+    --aspect)     ASPECT="${2:-}"; shift 2 ;;
+    --ref)        REFS+=("${2:-}"); shift 2 ;;
+    --attempts)   ATTEMPTS="${2:-}"; shift 2 ;;
+    --min-bytes)  MIN_BYTES="${2:-}"; shift 2 ;;
+    --model)      MODEL="${2:-}"; shift 2 ;;
+    --effort)     EFFORT="${2:-}"; shift 2 ;;
+    --timeout)    TIMEOUT_SEC="${2:-}"; shift 2 ;;
+    -h|--help)    sed -n '2,30p' "$0"; exit 0 ;;
+    *) echo "❌ 不明な引数: $1" >&2; exit 2 ;;
+  esac
+done
+
+[ -n "$PROMPT" ] || { echo "❌ --prompt は必須" >&2; exit 2; }
+[ -n "$OUT" ]    || { echo "❌ --out は必須" >&2; exit 2; }
+command -v codex >/dev/null 2>&1 || { echo "❌ codex CLI が見つからない（codex-imagegen は Codex CLI に依存する）" >&2; exit 2; }
+
+OUT_DIR="$(cd "$(dirname "$OUT")" 2>/dev/null && pwd)" || {
+  mkdir -p "$(dirname "$OUT")" && OUT_DIR="$(cd "$(dirname "$OUT")" && pwd)"
+}
+OUT_ABS="$OUT_DIR/$(basename "$OUT")"
+
+# ---- 検品（決定論・LLM を使わない）-------------------------------------------
+# 実ファイルのみを見る。codex の自己申告は根拠にしない（ADR-019）。
+verify_image() {
+  local f="$1"
+  [ -f "$f" ] || { echo "  検品: ❌ ファイルが存在しない ($f)"; return 1; }
+
+  local bytes
+  bytes=$(wc -c < "$f" | tr -d ' ')
+  if [ "$bytes" -lt "$MIN_BYTES" ]; then
+    echo "  検品: ❌ サイズ過小 ${bytes}B < ${MIN_BYTES}B（空/切断の疑い）"
+    return 1
+  fi
+
+  python3 - "$f" <<'PY'
+import struct, sys
+p = sys.argv[1]
+d = open(p, 'rb').read()
+if d[:8] == b'\x89PNG\r\n\x1a\n':
+    # IHDR は必ず先頭チャンク
+    if d[12:16] != b'IHDR':
+        print("  検品: ❌ PNG だが IHDR が無い（破損）"); sys.exit(1)
+    w, h = struct.unpack('>II', d[16:24])
+    fmt = 'PNG'
+elif d[:3] == b'\xff\xd8\xff':
+    w = h = None
+    i = 2
+    while i < len(d) - 9:
+        if d[i] != 0xFF:
+            i += 1; continue
+        m = d[i+1]
+        if m in (0xC0,0xC1,0xC2,0xC3,0xC5,0xC6,0xC7,0xC9,0xCA,0xCB,0xCD,0xCE,0xCF):
+            h, w = struct.unpack('>HH', d[i+5:i+9]); break
+        if m in (0xD8,0xD9) or 0xD0 <= m <= 0xD7:
+            i += 2; continue
+        seg = struct.unpack('>H', d[i+2:i+4])[0]
+        i += 2 + seg
+    if w is None:
+        print("  検品: ❌ JPEG だが SOF が見つからない（破損）"); sys.exit(1)
+    fmt = 'JPEG'
+else:
+    print(f"  検品: ❌ 画像フォーマット不明（先頭バイト {d[:4]!r}）"); sys.exit(1)
+
+if w < 16 or h < 16:
+    print(f"  検品: ❌ 実寸が異常に小さい {w}x{h}"); sys.exit(1)
+
+print(f"  検品: ✅ {fmt} {w}x{h} / {len(d)} bytes")
+PY
+}
+
+# ---- 生成 -------------------------------------------------------------------
+ASPECT_LINE=""
+[ -n "$ASPECT" ] && ASPECT_LINE="アスペクト比は ${ASPECT} を狙ってください。"
+
+REF_ARGS=()
+for r in "${REFS[@]:-}"; do
+  [ -n "$r" ] && REF_ARGS+=(-i "$r")
+done
+
+attempt=1
+while [ "$attempt" -le "$ATTEMPTS" ]; do
+  echo "▶ codex-imagegen 試行 ${attempt}/${ATTEMPTS} → $OUT_ABS"
+  rm -f "$OUT_ABS"
+
+  REQ="image_gen ツールを使って次の画像を1枚生成し、生成された画像ファイルを必ず絶対パス '${OUT_ABS}' にコピーして保存してください。
+${ASPECT_LINE}
+保存後は、そのパスとバイトサイズだけを短く報告してください。画像の説明文や講評は不要です。
+Python やベクタ描画で自前に画像を描くことは禁止です（必ず image_gen を使う）。
+
+--- 生成する画像 ---
+${PROMPT}"
+
+  # codex が対象ディレクトリに書けるよう workspace-write で実行する。
+  # 引数配列は空のとき展開しない（"${arr[@]:-}" は空文字を 1 個渡してしまい codex が usage エラーになる）。
+  CMD=(codex exec --skip-git-repo-check --sandbox workspace-write
+       -m "$MODEL" -c model_reasoning_effort="$EFFORT")
+  [ ${#REF_ARGS[@]} -gt 0 ] && CMD+=("${REF_ARGS[@]}")
+  CMD+=("$REQ")
+
+  # macOS には timeout(1) が無い。gtimeout / timeout があれば使い、無ければ無防備で走らせず警告する。
+  if command -v gtimeout >/dev/null 2>&1;  then CMD=(gtimeout "$TIMEOUT_SEC" "${CMD[@]}")
+  elif command -v timeout >/dev/null 2>&1; then CMD=(timeout  "$TIMEOUT_SEC" "${CMD[@]}")
+  else echo "  ⚠️ timeout(1) 不在のため上限秒を強制できない（brew install coreutils で gtimeout 導入可）"; fi
+
+  ( cd "$OUT_DIR" && "${CMD[@]}" ) >/tmp/codex-imagegen-$$.log 2>&1
+  rc=$?
+
+  if [ $rc -ne 0 ]; then
+    echo "  codex exec が非ゼロ終了 (rc=$rc)。末尾ログ:"
+    tail -5 /tmp/codex-imagegen-$$.log | sed 's/^/    /'
+  fi
+
+  if verify_image "$OUT_ABS"; then
+    rm -f /tmp/codex-imagegen-$$.log
+    echo "✅ 生成 + 検品 pass: $OUT_ABS"
+    echo "⚠️  対外公開する前に、必ず人間（または別エージェント）が実ファイルを目視すること。"
+    echo "    検品が保証するのは『妥当な画像ファイルであること』だけで、内容の正しさではない。"
+    exit 0
+  fi
+
+  attempt=$((attempt + 1))
+done
+
+echo "❌ ${ATTEMPTS} 回試行しても検品を通らなかった: $OUT_ABS"
+echo "   codex ログ: /tmp/codex-imagegen-$$.log"
+exit 1

--- a/skills/codex-imagegen/SKILL.md
+++ b/skills/codex-imagegen/SKILL.md
@@ -1,0 +1,79 @@
+---
+name: codex-imagegen
+description: Generate images by delegating to the Codex CLI's built-in image_gen tool, then verify the saved file deterministically (magic bytes + real dimensions) before it is used. Runs on a ChatGPT subscription — no image API key required. Triggers: 画像生成, 画像を作る, image generation, generate image, アイコン生成, バナー生成, OGP 画像, サムネイル, illustration, codex image, imagegen, ビジュアル作成
+allowed-tools: Bash, Read, Glob, Grep
+---
+
+# codex-imagegen — Codex CLI 経由の画像生成 + 決定論検品
+
+> 実装: `scripts/codex-imagegen.sh`
+> **生成（非決定的・LLM）と 検品（決定論・スクリプト）を分離する**という ADR-019「自己申告禁止」の画像版。
+> エージェントの「画像を作りました」を成果の根拠にしない。**保存された実ファイル**だけが根拠。
+
+## いつ使うか
+
+- アイコン / バナー / OGP 画像 / サムネイル / 記事挿絵など、**ラスタ画像を新規生成**したいとき
+- 参照画像を渡して**同じ世界観の別カット**を作りたいとき（`--ref`）
+
+## いつ使わないか
+
+- **図表・チャート・グラフ** → 画像生成ではなくデータ可視化（`dataviz` 等）を使う。数値を LLM に描かせない
+- **ロゴの確定版・ブランド資産の刷新** → 生成は可だが**採用は Level 3**（ブランド）。本 skill は候補出しまで
+- **既存画像のリサイズ・変換だけ** → `sips` / ImageMagick で足りる。LLM を経由しない
+
+## 前提
+
+- `codex` CLI がインストール済みで **ログイン済み**（`codex login status`）
+- 認証は **ChatGPT サブスクリプション**で足りる。**画像 API キーは不要**（= 追加課金なし）
+- 内部ツール名は `image_gen__imagegen`（Codex 側の組み込み。MCP や plugin の追加登録は不要）
+
+## 使い方
+
+```bash
+scripts/codex-imagegen.sh \
+  --prompt "濃紺の背景に、白い細線で描かれた幾何学パターン。文字は入れない。" \
+  --aspect "16:9" \
+  --out assets/img/banner.png
+```
+
+| オプション | 既定 | 説明 |
+|---|---|---|
+| `--prompt <text>` | （必須） | 生成指示 |
+| `--out <path>` | （必須） | 出力パス（`.png` / `.jpg`） |
+| `--aspect <spec>` | — | `1:1` / `16:9` / `4:5` 等。**実測で概ね反映される**が厳密保証はしない |
+| `--ref <file>` | — | 参照画像（繰り返し可） |
+| `--attempts <n>` | 2 | 検品失敗時の再試行回数 |
+| `--min-bytes <n>` | 10000 | 空 / 切断ファイルの検知しきい値 |
+| `--model <name>` | `gpt-5.6-sol` | Codex のモデル |
+| `--effort <level>` | `low` | reasoning effort |
+| `--timeout <sec>` | 300 | 1 回あたり上限（`gtimeout`/`timeout` がある時のみ強制） |
+
+**Exit code**: `0` = 生成 + 検品 pass / `1` = 検品 fail（試行使い切り）/ `2` = 引数誤り・`codex` 不在
+
+## 検品が保証すること・しないこと
+
+スクリプトが決定論的に検査するのは**実ファイル**のみ:
+
+- ファイルが存在する（`codex` の自己申告ではなく `--out` のパスを見る）
+- マジックバイトが PNG / JPEG として妥当（PNG は `IHDR` の存在まで）
+- 実寸が取得でき、極端に小さくない
+- バイト数が `--min-bytes` 以上
+
+**保証しないのは「絵の内容が意図通りか」**。exit 0 は「妥当な画像ファイルである」までしか言っていない。
+→ **対外公開の前に必ず人間（または別エージェントの Verifier）が実ファイルを目視する。**
+
+## Gotchas（実測で踏んだもの）
+
+- **プレビューと実ファイルは別物** — 2026-07-31 に別の生成系で、プレビューは正しいのに DL したフルサイズが違うという事例があった。**検品は必ず保存済みの実ファイルに対して行う**（本スクリプトはそう作ってある）
+- **exit 0 ≠ 正しい絵** — 「ステータスが通った」で完了報告しない。API 検証で「200 ≠ 正しい」と同じ罠
+- **ブランド色を記憶で決めない** — 「あの製品は青」のような記憶は外れる（実例: PULSE の色だと思っていたものが実際は fit-ai のブランド色だった）。**デザインシステムの実値を引いてからプロンプトに書く**
+- **reasoning effort を上げても絵は良くならない** — `--effort low` が既定。上げるとコストと時間だけ増える
+- **空配列の展開に注意**（スクリプト保守者向け）— `"${arr[@]:-}"` は空文字を 1 個渡してしまい `codex exec` が usage エラーになる。`[ ${#arr[@]} -gt 0 ] && CMD+=("${arr[@]}")` で回避済み
+- **macOS に `timeout(1)` は無い** — `gtimeout`（coreutils）が無ければ上限秒は強制されず、警告だけ出る
+- **生成物は `~/.codex/generated_images/<session>/` にも残る** — 秘匿性のある素材を生成した場合はそちらの残骸も意識する
+
+## 承認レベル
+
+- **生成そのもの = Level 1**（内部・可逆・非金銭）。サブスク内で完結し追加課金は発生しない
+- **対外公開 = Level 2 以上**。SNS / サイト / 配布物に載せる判断は本 skill の外
+- **ブランド資産の確定 = Level 3**（ブランド）


### PR DESCRIPTION
## 何を足したか

Codex CLI の**組み込み画像生成ツール `image_gen__imagegen`** を、Claude Code / 他エージェントから 1 コマンドで叩けるようにする skill。

- `scripts/codex-imagegen.sh` — 生成 + 決定論検品のラッパー
- `skills/codex-imagegen/SKILL.md` — 使い所・境界・gotchas・承認レベル

## なぜ API キーが要らないか

Codex は **ChatGPT サブスクリプション認証**で `image_gen` を使える（`codex login status` = `Logged in using ChatGPT`）。
別途 image API キーを持つ必要がなく、**追加課金なし**で画像生成できる。MCP / plugin の追加登録も不要。

## 設計: 生成と検品の分離（ADR-019 の画像版）

エージェントの「画像を作りました」は根拠にしない。スクリプトが**保存された実ファイル**に対して決定論的に:

- ファイル存在（自己申告ではなく `--out` のパスを見る）
- マジックバイト（PNG は `IHDR` まで / JPEG は SOF まで）
- 実寸・バイト数

を検査して初めて `exit 0`。**プレビューは正しいのに DL したフルサイズが違った**という別生成系での実事故を構造的に防ぐため、検品対象は必ず実ファイル。

`exit 0` が保証するのは「妥当な画像ファイルであること」までで**絵の内容の正しさではない**。対外公開前の目視要求を SKILL.md と実行時出力の両方に出している。

## 実測（macOS / codex-cli 0.146.0）

| ケース | 結果 |
|---|---|
| 青い円 | PNG **1254x1254** / 747KB・目視一致 |
| 16:9 バナー（`--aspect 16:9`） | PNG **1672x941**（比 1.777）/ 1.05MB・目視一致 |

→ aspect 指定は概ね反映されるが**厳密保証ではない**と SKILL.md に明記した。

## 実装中に踏んだ罠（コメントで固定済み）

- `"${arr[@]:-}"` は空配列のとき**空文字を 1 個渡す** → `codex exec` が usage エラー。`[ ${#arr[@]} -gt 0 ]` ガードで回避
- **macOS に `timeout(1)` は無い** → `gtimeout`/`timeout` があれば使い、無ければ警告して続行（黙って無防備にしない）

## 承認レベル

生成自体は Level 1（内部・可逆・非金銭）。対外公開は Level 2 以上、ブランド資産の確定は Level 3 と SKILL.md に明記。