### PR TITLE
docs: 公開ドキュメントから社内記録へのポインタを外す

### DIFF
--- a/docs/known-stack-coverage.md
+++ b/docs/known-stack-coverage.md
@@ -139,7 +139,10 @@ real adoption need surfaces.
 
 ## Related references
 
-- 14-day verification log: i-willink-crew `assets/knowledge/2026-04-26-claude-kit-validation-log.md`
-- Day 7 mid-term report: `assets/knowledge/2026-05-04-claude-kit-interim-report.md`
-- v1.0 Go/No-Go report: `assets/knowledge/2026-05-10-claude-kit-validation-report.md`
 - Verification protocol: `docs/verification-protocol.md`
+- Release history: `CHANGELOG.md`
+
+The 14-day verification log, the day-7 interim report and the v1.0 Go/No-Go report are
+internal records and are not published. What this document and the verification protocol
+state is the full extent of what is public — the pointers above are the only ones a reader
+outside the organization can follow.

--- a/docs/verification-protocol.md
+++ b/docs/verification-protocol.md
@@ -110,4 +110,4 @@ stack promotion（🟡 → ✅）の判断基準は本書では定義しない�
 - 当時の Go/No-Go 基準（tool call -20% / CONDITIONAL/FAIL 率 -30% / context 1.3x /
   MEMORY 5 件 / 致命的失敗 0）のうち、未検証だった MEMORY と context の 2 指標が
   上記「v1.1 継続評価指標」へ繰り越された。**この旧基準を現在の運用基準として使わないこと**
-- 詳細: CHANGELOG `[1.0.0]`・i-willink-crew `assets/knowledge/2026-05-10-claude-kit-validation-report.md`
+- 詳細: CHANGELOG `[1.0.0]`（Go/No-Go の一次記録は社内記録のため非公開）


### PR DESCRIPTION
公開リポに、非公開リポの名前と社内ファイルパスが **4 行**残っていました。

| ファイル | 内容 |
|---|---|
| `docs/known-stack-coverage.md` | Related references の 3 行が丸ごと社内記録へのポインタ。うち 1 行はリポ名も記載 |
| `docs/verification-protocol.md` | 詳細行に同じリポ名 |

いずれも **OSS の読者からは到達できないパス**で、示しているのは「社内にどんなリポがあり、どこに何が置いてあるか」だけです。

到達できるポインタ（`docs/verification-protocol.md` / `CHANGELOG.md`）だけ残し、一次記録が非公開であることを明記しました。消して黙るのではなく「公開しているのはここまで」と書く形にしています。

## 実測

走査 **188 ファイル** / `i-willink-crew|willink-labs/|i-Willink-LLC/` **0 件**・個人パス **0 件**（修正前は 2 ファイル）。

なお同じ走査で `hooks/pre-status-verify-guard.sh` にも社内記録パスが 1 件見つかりましたが、これは正本から export されたものなので**正本側で直します**（一方向パイプラインを逆走しない）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)