### PR TITLE
release: v2.6.0 — 正本から export した Core を実際に配布する

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,10 +10,10 @@
       "source": {
         "source": "url",
         "url": "https://github.com/willink-oss/willink-claude-kit.git",
-        "ref": "willink-claude-kit--v2.5.0"
+        "ref": "willink-claude-kit--v2.6.0"
       },
       "description": "標準サブエージェント 4 本 + 5 phase /build フローを束ねた開発キット。Generator-Verifier 分離・並列探索・project-standards 拡張・アクセシビリティを既定で設計する 3 層に対応。",
-      "version": "2.5.0",
+      "version": "2.6.0",
       "category": "development"
     }
   ]

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "willink-claude-kit",
-  "version": "2.5.0",
+  "version": "2.6.0",
   "description": "i-Willink 標準開発エージェント基盤。dev-explorer / dev-planner / dev-tester / dev-reviewer の 4 サブエージェント + 5 phase /build コマンドを Claude Code Plugin として提供。",
   "author": {
     "name": "i-Willink合同会社",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "willink-claude-kit",
-  "version": "2.5.0",
+  "version": "2.6.0",
   "description": "i-Willink 標準開発エージェント基盤を Codex でも使うための plugin。Claude Code 版を正本にし、Codex 向け adapter skill と同期チェックを提供する。",
   "author": {
     "name": "i-Willink合同会社",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,34 @@ All notable changes follow [Keep a Changelog](https://keepachangelog.com/en/1.1.
 
 ## [Unreleased]
 
+## [2.6.0] - 2026-09-10
+
+**Status**: 開発標準とハーネスの正本リポから **Core を export した最初のリリース**。skill **26 本** / hook **14 本** / 決定論エンジン **13 本** / ハーネス文書 **6 本** を追加する。hooks はこれが初搭載。破壊的変更なし（既存 17 skill と名前衝突 0・上書きは `scripts/goal-loop.sh` の 1 本だけで、正本側を正とする）。
+
+本版は「**merged ≠ shipped**」の 2 度目の実例でもある。2.5.0 は同じ理由（main に merge 済みだが version を上げず marketplace の `source.ref` が旧タグに固定）で作った版で、今回も 68 ファイルを main に入れた時点では**どの導入先にも届いていなかった**。公開リポで見えることと配布されていることは別で、`ref` を上げるまで配布は起きない。
+
+### Added
+
+- **決定論エンジン 13 本**（`scripts/`）— 「エージェントの自己申告を採点に使わない」を実装する層。合否は exit code だけで決める。`eval-harness.py`（回帰の分母）/ `govern.py`（ミスの蒸留）/ `agentlog.py` / `harness-lint.py` / `secret-scan-audit.py`（既知 25 形式の鍵に対する検出網羅率）/ `rule-promotion.py` / `required-check-audit.sh` / `destructive-audit.sh` / `gate-forge.sh`（ミス 1 件から hook を起こす）/ `advisory-tally.py` / `regenerate-knowledge-index.py` / `codex-spark.sh` / `goal-loop.sh`。すべて Python3 標準ライブラリと POSIX shell のみで動き、**ネットワークを使わない**。
+- **hook 14 本**（`hooks/`）— `pre-bash-safety.sh` / `pre-file-protect.sh` / `pre-write-collision.sh` / `pre-commit-quality.sh` / `pre-commit-shell-lint.sh` / `pre-commit-silent-zero.sh` / `pre-status-verify-guard.sh` / `post-commit-verify.sh` / `post-file-eval.sh` / `post-tool-log.sh` / `pre-compact-snapshot.sh` / `review-gate.sh` / `instructions-loaded-log.sh` / `_advisory-log.sh`。**settings.json への登録は行わない**（導入先の hook 設定を勝手に書き換えない）。13/14 が自己完結で、外部台帳に依存する 1 本は台帳が無ければ理由を 1 行出して skip する。
+  - **環境依存を設定駆動にした** — 直 push を許すリポは `HARNESS_DIRECT_PUSH_REPOS`（既定は空 = 常に PR を要求）、レビューゲートの一覧は `.claude/review-gates.tsv` / `REVIEW_GATES_FILE`。`hooks/review-gates.example.tsv` を同梱。
+- **skill 26 本**（`skills/`）— ハーネスの運用側。`gate-forge` / `mistake-rule-distill` / `eval-regression-guard` / `eval-dataset-build` / `secret-scan-hardening` / `destructive-env-guard` / `review-finding-repro` / `harness-kpi-ledger` / `hallucination-rate-meter` / `context-bloat-tracker` / `session-length-compact-audit` / `subagent-usage-analyzer` / `task-success-rate-track` / `retry-failure-classifier` / `prompt-ab-eval` / `commit-msg-quality-score` / `rule-promote-audit` / `rule-promotion-extract` / `rule-dedup-scan` / `trigger-vocab-dedup` / `knowledge-index-guard` / `knowledge-dedup-scan` / `knowledge-citation-coverage` / `memory-distill` / `ci-required-check-installer` / `codex-spark-delegate`。
+- **ハーネス文書 6 本**（`docs/harness/`）— `principles.md` / `practices.md` / `wiring.md` / `incidents.md` / `oss-vs-pro.md` / `product-readme.md`。由来が分かるよう名前空間を切ってある。
+- **`docs/harness/manifest.txt`** — 正本から export した資産の一覧（`<kind>\tpath`・53 行）。同梱の `scripts/verify-harness.sh` は**この manifest を分母にする**ので、導入先の既存ファイルを巻き込まずに「出した分」だけを検査する。glob で検査していた版は導入先の全 script を走査してタイムアウトし、自分自身を engine として再帰起動していた。
+- **`CONTRIBUTING.md` / `CODEOWNERS` / `.github/pull_request_template.md` / `NOTICE.md`** — 外部からの貢献を受ける口。実装の変更は**正本リポへ**戻る一方向で、公開リポは配布物であることを明記した。
+
+### Changed
+
+- `scripts/goal-loop.sh` を正本側の版に置き換えた（唯一の上書き）。exit code 契約は同じで、`--reset` / `--state` の扱いと自己テストが増えている。
+
+### Fixed
+
+- **公開ドキュメントから社内記録へのポインタを除去**（`docs/known-stack-coverage.md` / `docs/verification-protocol.md`）。非公開リポの名前と、外部からは到達できない社内ファイルパスが計 4 行残っていた。一次記録が非公開であることは明記し、到達できるポインタだけ残した。
+
+### 含まれないもの（3 段階配布の境界）
+
+`fixtures/` `profiles/` `adapters/` は**入っていない**。OSS（無料 MIT）は Core の hook / skill / engine までで、fixture は実案件のバグ由来のため有料チャネルの差別化要素にあたる。境界は正本リポの CI が機械で検査しており、混ざると export が失敗する。
+
 ## [2.5.0] - 2026-08-06
 
 **Status**: 2.4.0 以降 main に入っていた 2 skill（`codex-imagegen` / `cogload-dashboard`）を**実際に配布する**リリース。両者は main に merge 済みだったが `plugin.json` の version を上げていなかったため、marketplace の `source.ref` が v2.4.0 タグに固定されたまま = **導入先リポジトリのどこからもロードされていなかった**。「merged ≠ shipped」が plugin 配布にも当てはまることの実例で、本版はその解消が主目的。あわせて両 skill の実行例が repo-relative パス（`scripts/...`）を書いており、kit 以外の CWD では解決できなかったのを `${CLAUDE_PLUGIN_ROOT:-.}` に統一した（他 skill は既にこの規約）。破壊的変更なし。

--- a/codex/sync-manifest.json
+++ b/codex/sync-manifest.json
@@ -1,11 +1,11 @@
 {
   "schemaVersion": 1,
-  "updatedAt": "2026-08-06",
+  "updatedAt": "2026-09-10",
   "sourceOfTruth": "Claude Code plugin files are canonical; Codex and Antigravity files are platform adapters checked for drift.",
   "canonicalFiles": [
     {
       "path": ".claude-plugin/plugin.json",
-      "sha256": "d8afb3f74fbf97f3d919d18bfde0892f1214d2810b89a83be5c31dca31e11788",
+      "sha256": "40da4e04bd3d99d34767b928981114f3b8093893cc128c26ac254bb0af2e87b9",
       "codexAdapters": [
         ".codex-plugin/plugin.json",
         "skills/codex-build/SKILL.md"
@@ -16,7 +16,7 @@
     },
     {
       "path": ".claude-plugin/marketplace.json",
-      "sha256": "3c63c3884d6a89d90f370d530ad34ecbf970ccfde4e4135b3c1cb07842591a1b",
+      "sha256": "6921a13ba8c569b7226cc54161aaaec8e5c6978cd39ab6bf1cf07a0f4448858b",
       "codexAdapters": [
         ".codex-plugin/plugin.json",
         "skills/codex-build/SKILL.md"


### PR DESCRIPTION
68 ファイルを main に入れました（[#52](https://github.com/willink-oss/willink-claude-kit/pull/52) / [#54](https://github.com/willink-oss/willink-claude-kit/pull/54)）が、`marketplace.json` の `source.ref` は `willink-claude-kit--v2.5.0` に固定されたままです。

**公開リポで見えることと配布されていることは別**で、`ref` を上げるまでどの導入先にもロードされません。

2.5.0 自体が同じ理由で作った版（merge 済みだが version を上げていなかった 2 skill）なので、これは **2 度目の「merged ≠ shipped」**です。今回は export した 68 ファイル全部が対象でした。

## 上げたもの

| ファイル | |
|---|---|
| `.claude-plugin/plugin.json` | version → 2.6.0 |
| `.codex-plugin/plugin.json` | version → 2.6.0 |
| `.claude-plugin/marketplace.json` | version → 2.6.0 / **`ref` → `willink-claude-kit--v2.6.0`**（配布の実体） |
| `CHANGELOG.md` | 2.6.0 の項目（内訳と、`fixtures/` `profiles/` `adapters/` を**入れない**境界の理由） |
| `codex/sync-manifest.json` | ハッシュ再計算（`check_sync.py --update`） |

## 実測

- `check_sync.py --check` → **PASS**
- `scripts/test/run.sh` → **21 test file(s), 0 failed / ALL GREEN**
- `scripts/verify-harness.sh`（同梱）→ **18/18**

merge 後にタグ `willink-claude-kit--v2.6.0` と GitHub Release を作ります（この repo には release workflow が無く手動です）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)