### PR TITLE
fix(doctor): hooks を数え、旧版を HEALTHY と言わないようにする（v2.6.1）

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,10 +10,10 @@
       "source": {
         "source": "url",
         "url": "https://github.com/willink-oss/willink-claude-kit.git",
-        "ref": "willink-claude-kit--v2.6.0"
+        "ref": "willink-claude-kit--v2.6.1"
       },
       "description": "標準サブエージェント 4 本 + 5 phase /build フローを束ねた開発キット。Generator-Verifier 分離・並列探索・project-standards 拡張・アクセシビリティを既定で設計する 3 層に対応。",
-      "version": "2.6.0",
+      "version": "2.6.1",
       "category": "development"
     }
   ]

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "willink-claude-kit",
-  "version": "2.6.0",
+  "version": "2.6.1",
   "description": "i-Willink 標準開発エージェント基盤。dev-explorer / dev-planner / dev-tester / dev-reviewer の 4 サブエージェント + 5 phase /build コマンドを Claude Code Plugin として提供。",
   "author": {
     "name": "i-Willink合同会社",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "willink-claude-kit",
-  "version": "2.6.0",
+  "version": "2.6.1",
   "description": "i-Willink 標準開発エージェント基盤を Codex でも使うための plugin。Claude Code 版を正本にし、Codex 向け adapter skill と同期チェックを提供する。",
   "author": {
     "name": "i-Willink合同会社",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,20 @@ All notable changes follow [Keep a Changelog](https://keepachangelog.com/en/1.1.
 
 ## [Unreleased]
 
+## [2.6.1] - 2026-09-10
+
+**Status**: `scripts/check-kit-enabled.sh`（doctor）が **hooks を数えず、旧版を HEALTHY と報告していた**のを直す。2.6.0 で hooks を初搭載したが、doctor は 162 行のうち hook への言及が 0 行だった。機能追加なし・破壊的変更なし。
+
+### Fixed
+
+- **doctor が「壊れている」と「古い」を別の診断として出すようになった。** 導入済み版数（`installed_plugins.json`）と marketplace のローカル複製が配っている版数を比べ、食い違えば `NG` にする。旧版は**それ自体としては健全**なので、比較しない限り doctor は HEALTHY を返す。実際に v2.5.0 のまま「skills 17 件・HEALTHY」と出しながら、公開済みの hook 14 本 / engine 13 本 / skill 26 本が 1 つも入っていない状態を観測した（`ref` を上げるまで配布は起きないため）。
+  - 比較するのは**手元の 2 つ**だけで、ネットワークは見ない。marketplace の複製自体が古い場合は検出できないので、そう書いてある。読めなければ `??`（不明）で、**単独では落とさない** — 不明を OK とも NG とも書かない。
+- **doctor が hooks を数えるようになった。** 本数に加えて**実行可能ビット**も見る（置いてあるだけの hook は効かない）。欠けていれば `chmod +x` を案内する。hooks が `settings.json` へ自動登録されないことも毎回 1 行出す。
+
+### Added
+
+- `scripts/test/test_doctor_version_and_hooks.sh`（13 assertion）— 版数一致で exit 0 / 旧版で exit 1 かつ HEALTHY と言わない / hooks の本数を出す / hooks 不在を検出 / `+x` 欠けで exit 1 かつ**案内どおり `chmod +x` すれば通る** / marketplace 不明は落とさない。変異試験で hooks の計数を消すと 1 件落ちることを確認済み。
+
 ## [2.6.0] - 2026-09-10
 
 **Status**: 開発標準とハーネスの正本リポから **Core を export した最初のリリース**。skill **26 本** / hook **14 本** / 決定論エンジン **13 本** / ハーネス文書 **6 本** を追加する。hooks はこれが初搭載。破壊的変更なし（既存 17 skill と名前衝突 0・上書きは `scripts/goal-loop.sh` の 1 本だけで、正本側を正とする）。

--- a/codex/sync-manifest.json
+++ b/codex/sync-manifest.json
@@ -5,7 +5,7 @@
   "canonicalFiles": [
     {
       "path": ".claude-plugin/plugin.json",
-      "sha256": "40da4e04bd3d99d34767b928981114f3b8093893cc128c26ac254bb0af2e87b9",
+      "sha256": "8edfda65b057ba3759c501a32e476fd2314dc14ef78f4842da53c417fa23179e",
       "codexAdapters": [
         ".codex-plugin/plugin.json",
         "skills/codex-build/SKILL.md"
@@ -16,7 +16,7 @@
     },
     {
       "path": ".claude-plugin/marketplace.json",
-      "sha256": "6921a13ba8c569b7226cc54161aaaec8e5c6978cd39ab6bf1cf07a0f4448858b",
+      "sha256": "ed2fcf80ce2c4bef88e337d9de596eebf189b408f4ee27ab46f19cec98cade56",
       "codexAdapters": [
         ".codex-plugin/plugin.json",
         "skills/codex-build/SKILL.md"

--- a/scripts/check-kit-enabled.sh
+++ b/scripts/check-kit-enabled.sh
@@ -118,6 +118,36 @@ if [ -n "$INSTALL_PATH" ]; then
   fi
 fi
 
+# インストール済み版数 vs marketplace が配っている版数。
+#
+# なぜ要るか（2026-09-10 に 2 度目を踏んだ）: main に merge しても
+# `marketplace.json` の `source.ref` を上げなければ、導入先には旧版が居座る。
+# 旧版は**それ自体としては健全**なので、この doctor は HEALTHY を返してしまう。
+# 実際に v2.5.0 のまま「skills 17 件・HEALTHY」と出しながら、公開済みの
+# hook 14 本・engine 13 本・skill 26 本が 1 つも入っていない状態を見た。
+# **「壊れている」と「古い」は別の診断**なので、別の行で出す。
+#
+# 比較するのは **手元の 2 つ**（installed_plugins.json と marketplace のローカル複製）。
+# ネットワークは見ないので、複製自体が古い場合は検出できない。読めなければ
+# `??` にする（**不明を OK と書かない**）。
+MP_JSON="$CLAUDE_HOME/plugins/marketplaces/iwillink/.claude-plugin/marketplace.json"
+if [ -f "$MP_JSON" ]; then
+  MP_VER="$(json_get "$MP_JSON" "next((p.get('version','') for p in d.get('plugins',[]) if p.get('name')=='willink-claude-kit'), '')")"
+  if [ -z "$MP_VER" ]; then
+    c_warn "marketplace.json から version を読めない（0 件ではなく不明）: $MP_JSON"
+  elif [ -z "${VER:-}" ]; then
+    c_warn "installed version が不明のため版数を比較できない"
+  elif [ "$MP_VER" = "$VER" ]; then
+    c_ok "版数一致: installed=$VER / marketplace=$MP_VER"
+  else
+    c_bad "installed=$VER だが marketplace は $MP_VER — **旧版がロードされている**"
+    printf '       壊れてはいないが古い。新しい版の commands / skills / hooks は 1 つも入っていない。\n'
+    printf '       fix: /plugin から marketplace を update → willink-claude-kit を再 install → Claude Code 再起動\n'
+  fi
+else
+  c_warn "marketplace のローカル複製が無い（版数を比較できない）: $MP_JSON"
+fi
+
 # ---------------------------------------------------------------------------
 # 3. ロード対象の中身（コマンド / エージェント / スキル）
 # ---------------------------------------------------------------------------
@@ -143,6 +173,24 @@ if [ -n "$INSTALL_PATH" ] && [ -d "$INSTALL_PATH" ]; then
       c_bad "$d/ が無い"
     fi
   done
+
+  # hooks は 2.6.0 で初搭載。**数えていなければ「配られていない」に気づけない**。
+  # 実行可能でない hook は数から除く（置いてあるだけでは効かない）。
+  if [ -d "$INSTALL_PATH/hooks" ]; then
+    nh="$(find "$INSTALL_PATH/hooks" -maxdepth 1 -name '*.sh' -type f | wc -l | tr -d ' ')"
+    nx="$(find "$INSTALL_PATH/hooks" -maxdepth 1 -name '*.sh' -type f -perm -u+x | wc -l | tr -d ' ')"
+    if [ "$nh" -eq 0 ]; then
+      c_bad "hooks/ が空（.sh が 0 本）"
+    elif [ "$nx" -ne "$nh" ]; then
+      c_bad "hooks/ … $nh 本のうち実行可能 $nx 本（$((nh - nx)) 本に +x が無い）"
+      printf '       fix: chmod +x "%s"/hooks/*.sh\n' "$INSTALL_PATH"
+    else
+      c_ok "hooks/ … $nh 本（すべて実行可能）"
+    fi
+    printf '       ⚠️ hooks は settings.json へ自動登録されない。有効化は導入先の設定で行う。\n'
+  else
+    c_bad "hooks/ が無い — 2.6.0 以降で同梱。上の版数比較を確認する"
+  fi
 else
   c_warn "installPath 未確定のため中身検査をスキップ"
 fi

--- a/scripts/test/test_doctor_version_and_hooks.sh
+++ b/scripts/test/test_doctor_version_and_hooks.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+# doctor は「壊れている」と「古い」を別の診断として出せること、
+# および hooks を数えられること。
+#
+# 守っている回帰（2026-09-10・2 度目の「merged ≠ shipped」）:
+# main に merge しても `marketplace.json` の `source.ref` を上げなければ、
+# 導入先には旧版が居座る。旧版はそれ自体としては健全なので、doctor は
+# HEALTHY を返してしまう。実際に v2.5.0 のまま「skills 17 件・HEALTHY」と
+# 出しながら、公開済みの hook 14 本 / engine 13 本 / skill 26 本が
+# 1 つも入っていない状態を観測した。
+#
+# hooks を数えていなければ「配られていない」に気づく手段が無い。
+# shellcheck source=scripts/test/lib.sh
+source "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+DOCTOR="$KIT_ROOT/scripts/check-kit-enabled.sh"
+assert_file_exists "$DOCTOR" "doctor が在る"
+
+# 偽の CLAUDE_CONFIG_DIR を組み立てる。<installed> と <marketplace> の版数を指定できる。
+# $1=作業先 $2=installed ver $3=marketplace ver $4=hooks 本数 $5=hooks に +x を付けるか(yes/no)
+_mkhome() {
+  local home="$1" iver="$2" mver="$3" nhooks="$4" exec_ok="$5" ip
+  ip="$home/plugins/cache/iwillink/willink-claude-kit/$iver"
+  mkdir -p "$ip/.claude-plugin" "$ip/commands" "$ip/agents" "$ip/skills" \
+           "$home/plugins/marketplaces/iwillink/.claude-plugin"
+  printf '{"name":"willink-claude-kit","version":"%s"}\n' "$iver" > "$ip/.claude-plugin/plugin.json"
+  : > "$ip/commands/build.md"; : > "$ip/agents/a.md"; mkdir -p "$ip/skills/s"
+  if [ "$nhooks" -gt 0 ]; then
+    mkdir -p "$ip/hooks"
+    local i
+    for i in $(seq 1 "$nhooks"); do
+      printf '#!/usr/bin/env bash\nexit 0\n' > "$ip/hooks/h$i.sh"
+      [ "$exec_ok" = "yes" ] && chmod +x "$ip/hooks/h$i.sh"
+    done
+  fi
+  mkdir -p "$home/plugins"
+  printf '{"plugins":{"willink-claude-kit@iwillink":[{"installPath":"%s","version":"%s"}]}}\n' \
+    "$ip" "$iver" > "$home/plugins/installed_plugins.json"
+  printf '{"plugins":[{"name":"willink-claude-kit","version":"%s"}]}\n' "$mver" \
+    > "$home/plugins/marketplaces/iwillink/.claude-plugin/marketplace.json"
+  # settings.json は [1] が見る。boolean true = 正常な有効化。
+  printf '{"enabledPlugins":{"willink-claude-kit@iwillink":true}}\n' > "$home/settings.json"
+}
+
+# 出力はファイルへ落とす（assert_contains はファイルを取る。
+# 文字列を渡すと grep がファイル不在で失敗し、**偽の PASS** になる）
+_run() { CLAUDE_CONFIG_DIR="$1" bash "$DOCTOR" > "$OUT" 2>&1; }
+
+TMP="$(mktemp -d)"
+OUT="$TMP/out.txt"
+trap 'rm -rf "$TMP"' EXIT
+
+# --- pass 側: 版数一致 + hooks 14 本すべて実行可能 ---
+_mkhome "$TMP/ok" 2.6.0 2.6.0 14 yes
+_run "$TMP/ok"; rc=$?
+assert_eq "0" "$rc" "版数一致 + hooks 揃いなら exit 0"
+assert_contains "$OUT" "hooks/ … 14 本" "hooks を本数で数える"
+assert_contains "$OUT" "版数一致" "版数一致を明示する"
+
+# --- block 側 1: 旧版が居座っている（壊れてはいないが古い） ---
+_mkhome "$TMP/old" 2.5.0 2.6.0 0 yes
+_run "$TMP/old"; rc=$?
+assert_eq "1" "$rc" "installed < marketplace なら exit 1"
+assert_contains "$OUT" "旧版がロードされている" "「古い」を専用の診断として出す"
+assert_not_contains "$OUT" "HEALTHY" "古い版を HEALTHY と言わない"
+
+# --- block 側 2: hooks が同梱されていない ---
+assert_contains "$OUT" "hooks/ が無い" "hooks 不在を検出する"
+
+# --- 代替手順側: 案内どおり chmod +x すれば通る ---
+_mkhome "$TMP/noexec" 2.6.0 2.6.0 3 no
+_run "$TMP/noexec"; rc=$?
+assert_eq "1" "$rc" "+x の無い hook があれば exit 1"
+assert_contains "$OUT" "chmod +x" "案内する代替手順を出す"
+chmod +x "$TMP/noexec"/plugins/cache/iwillink/willink-claude-kit/2.6.0/hooks/*.sh
+_run "$TMP/noexec"; rc=$?
+assert_eq "0" "$rc" "案内どおり chmod +x すれば通る"
+
+# --- 不明を OK にも NG にもしない ---
+_mkhome "$TMP/nomp" 2.6.0 2.6.0 2 yes
+rm -f "$TMP/nomp/plugins/marketplaces/iwillink/.claude-plugin/marketplace.json"
+_run "$TMP/nomp"; rc=$?
+assert_contains "$OUT" "版数を比較できない" "marketplace が読めなければ不明と書く"
+assert_eq "0" "$rc" "不明は単独では落とさない（0 件と書かないが NG にもしない）"
+
+t_summary


### PR DESCRIPTION
2.6.0 で hooks を初搭載しましたが、`scripts/check-kit-enabled.sh` は **162 行のうち hook への言及が 0 行**でした。数えていなければ「配られていない」に気づく手段がありません。

さらに doctor は **旧版を HEALTHY と報告**していました。この環境で実際に観測した出力です:

```
OK   installed_plugins.json に登録あり (version=2.5.0)
OK   skills/ … 17 件
HEALTHY — 設定・実体ともに正常。
```

公開済みの hook 14 本 / engine 13 本 / skill 26 本が **1 つも入っていない**状態で HEALTHY です。旧版は*それ自体としては*健全なので、版数を比べない限り問題として出ません。

> **「壊れている」と「古い」は別の診断**です。別の行で出します。

## 直したこと

- 導入済み版数（`installed_plugins.json`）と marketplace のローカル複製の版数を比較。食い違えば `NG` + 具体的な fix
  - 比較するのは**手元の 2 つ**だけで、ネットワークは見ません。複製自体が古い場合は検出できないので、そう書いてあります
  - 読めなければ `??`（不明）で、**単独では落としません** — 不明を OK とも NG とも書かない
- hooks を**本数 + 実行可能ビット**で数える（置いてあるだけの hook は効かない）。欠けていれば `chmod +x` を案内
- hooks が `settings.json` へ自動登録されないことを毎回 1 行出す

## 実測

`scripts/test/test_doctor_version_and_hooks.sh` — **13 assertion / 0 failed**。block（旧版・hooks 不在・`+x` 欠け）/ pass / **案内どおり `chmod +x` すれば通る** / 不明は落とさない、の 4 面。変異試験で hooks の計数を消すと 1 件落ちます。全 **22 スイート緑**・`check_sync.py --check` PASS。

## 自己申告

試験の最初の版は `assert_contains` に**文字列**を渡していました（第 1 引数はファイル）。grep がファイル不在で失敗し、`assert_not_contains` が**偽の PASS** を返していました。ファイルへ落として書き直しています。

## 版数

この修正自体も `ref` を上げなければ届かないので **2.6.1** として出します。

🤖 Generated with [Claude Code](https://claude.com/claude-code)