### PR TITLE
harness: 正本から Core を export（skill 26 / hook 14 / engine 13）

### DIFF
--- a/docs/harness/wiring.md
+++ b/docs/harness/wiring.md
@@ -134,3 +134,45 @@ CLI オプション（`--root` `--rules-dir` `--skills-dir` `--memory-dir` `--kn
 止まったら、止まった理由を解決するか、人間の判断に上げてください。
 どちらもできないなら、そのゲートは最初から要りません
 （[`principles.md` P3](principles.md)）。
+
+---
+
+## plugin として入れた場合の hook（2026-09-10 実測）
+
+Claude Code の plugin は **`hooks/hooks.json`** を読んで hook を登録します。
+`plugin.json` に `hooks` キーを足すのではありません。**`hooks/*.sh` を同梱しただけでは
+1 本も登録されません**（v2.6.0 はこの状態で 14 本を配り、実効 0 本でした）。
+
+本 kit は `hooks/hooks.json` で **10 本**を登録します。
+
+| イベント | matcher | hook | 既定 |
+|---|---|---|---|
+| PreToolUse | `Bash` | `pre-bash-safety.sh` | **止める** |
+| PreToolUse | `Write\|Edit` | `pre-file-protect.sh` | **止める** |
+| PreToolUse | `Write` | `pre-write-collision.sh` | **止める** |
+| PostToolUse | `Bash` | `post-commit-verify.sh` | fail-open |
+| PostToolUse | `Write\|Edit` | `post-file-eval.sh` | fail-open |
+| PostToolUse | — | `post-tool-log.sh` | fail-open |
+| UserPromptSubmit | — | `pre-status-verify-guard.sh` | fail-open |
+| UserPromptSubmit | — | `review-gate.sh` | 設定が無ければ通す |
+| PreCompact | — | `pre-compact-snapshot.sh` | fail-open |
+| InstructionsLoaded | — | `instructions-loaded-log.sh` | fail-open |
+
+**同梱しているが登録しない 4 本**: `pre-commit-quality.sh` / `pre-commit-shell-lint.sh` /
+`pre-commit-silent-zero.sh` は **git の pre-commit hook** で、Claude Code のイベントには
+載りません（`.git/hooks/pre-commit` から呼びます）。`_advisory-log.sh` は共有ライブラリです。
+
+### 止める 3 本の既定
+
+- `pre-bash-safety.sh` — 直 push を許すリポは `HARNESS_DIRECT_PUSH_REPOS`（カンマ区切り）。
+  **既定は空 = 常に PR を要求**します。単独リポで直 push したい場合は設定してください。
+- `pre-file-protect.sh` / `pre-write-collision.sh` — 保護対象への上書きと、
+  同一ファイルへの衝突書き込みを止めます。
+
+### パスの前提
+
+hook は **`CLAUDE_PROJECT_DIR`**（無ければ `git rev-parse --show-toplevel`、それも無ければ `pwd`）を
+プロジェクトのルートとして使います。plugin 配下では `$0` は **plugin のキャッシュ**を指すため、
+`dirname "$0"` から遡ってリポジトリを推測すると、設定は永久に見つからず、
+ログとスナップショットが全プロジェクトで共有されます。`scripts/test-plugin-hooks.sh` が
+この書き方の再発を止めます。

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -1,0 +1,70 @@
+{
+  "description": "willink-claude-kit のハーネス hook。plugin として有効化すると Claude Code が登録する。ブロックする 3 本（PreToolUse）と、fail-open の 7 本に分かれる。",
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          { "type": "command", "command": "bash \"${CLAUDE_PLUGIN_ROOT}/hooks/pre-bash-safety.sh\"" }
+        ]
+      },
+      {
+        "matcher": "Write|Edit",
+        "hooks": [
+          { "type": "command", "command": "bash \"${CLAUDE_PLUGIN_ROOT}/hooks/pre-file-protect.sh\"" }
+        ]
+      },
+      {
+        "matcher": "Write",
+        "hooks": [
+          { "type": "command", "command": "bash \"${CLAUDE_PLUGIN_ROOT}/hooks/pre-write-collision.sh\"" }
+        ]
+      }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          { "type": "command", "command": "bash \"${CLAUDE_PLUGIN_ROOT}/hooks/post-commit-verify.sh\"" }
+        ]
+      },
+      {
+        "matcher": "Write|Edit",
+        "hooks": [
+          { "type": "command", "command": "bash \"${CLAUDE_PLUGIN_ROOT}/hooks/post-file-eval.sh\"" }
+        ]
+      },
+      {
+        "hooks": [
+          { "type": "command", "command": "bash \"${CLAUDE_PLUGIN_ROOT}/hooks/post-tool-log.sh\"" }
+        ]
+      }
+    ],
+    "UserPromptSubmit": [
+      {
+        "hooks": [
+          { "type": "command", "command": "bash \"${CLAUDE_PLUGIN_ROOT}/hooks/pre-status-verify-guard.sh\"" }
+        ]
+      },
+      {
+        "hooks": [
+          { "type": "command", "command": "bash \"${CLAUDE_PLUGIN_ROOT}/hooks/review-gate.sh\"" }
+        ]
+      }
+    ],
+    "PreCompact": [
+      {
+        "hooks": [
+          { "type": "command", "command": "bash \"${CLAUDE_PLUGIN_ROOT}/hooks/pre-compact-snapshot.sh\"" }
+        ]
+      }
+    ],
+    "InstructionsLoaded": [
+      {
+        "hooks": [
+          { "type": "command", "command": "bash \"${CLAUDE_PLUGIN_ROOT}/hooks/instructions-loaded-log.sh\"" }
+        ]
+      }
+    ]
+  }
+}

--- a/hooks/pre-bash-safety.sh
+++ b/hooks/pre-bash-safety.sh
@@ -69,7 +69,19 @@ block() {
 # UserPromptSubmit records an exact, session-scoped grant. This PreToolUse
 # check is fail-closed: a protected remote mutation cannot be inferred from
 # requests such as "share the link" or "prepare the files".
-ROOT_DIR="$(cd "$SCRIPT_DIR/../.." && pwd)"
+# 検査対象のリポジトリ（= 利用者のプロジェクト）を解決する。
+#
+# ⚠️ plugin として配ると `$0` は **plugin のキャッシュ配下**になる（2026-09-10 実測）。
+#    `dirname "$0"/../..` を「リポジトリのルート」として使うと、設定もログも
+#    plugin の中を指す。設定は永久に見つからず、ログは全プロジェクトで共有される。
+#    兄弟ファイル（`_advisory-log.sh` 等）を引くのに `$0` を使うのは正しい。
+#    **プロジェクトを指したいときだけ**これを使う。
+_project_dir() {
+  if [ -n "${CLAUDE_PROJECT_DIR:-}" ]; then printf '%s' "$CLAUDE_PROJECT_DIR"; return; fi
+  git rev-parse --show-toplevel 2>/dev/null || pwd
+}
+
+ROOT_DIR="$(_project_dir)"
 EXTERNAL_WRITE_GUARD="$ROOT_DIR/scripts/external-repo-write-guard.py"
 
 # Approval state is hook-owned. A model/tool command may not mint or edit it.

--- a/hooks/pre-compact-snapshot.sh
+++ b/hooks/pre-compact-snapshot.sh
@@ -13,7 +13,21 @@
 set -uo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
-SNAPSHOT_FILE="$SCRIPT_DIR/.compact-snapshot"
+# 検査対象のリポジトリ（= 利用者のプロジェクト）を解決する。
+#
+# ⚠️ plugin として配ると `$0` は **plugin のキャッシュ配下**になる（2026-09-10 実測）。
+#    `dirname "$0"/../..` を「リポジトリのルート」として使うと、設定もログも
+#    plugin の中を指す。設定は永久に見つからず、ログは全プロジェクトで共有される。
+#    兄弟ファイル（`_advisory-log.sh` 等）を引くのに `$0` を使うのは正しい。
+#    **プロジェクトを指したいときだけ**これを使う。
+_project_dir() {
+  if [ -n "${CLAUDE_PROJECT_DIR:-}" ]; then printf '%s' "$CLAUDE_PROJECT_DIR"; return; fi
+  git rev-parse --show-toplevel 2>/dev/null || pwd
+}
+
+_SNAP_DIR="$(_project_dir)/.claude"
+mkdir -p "$_SNAP_DIR" 2>/dev/null || _SNAP_DIR="$SCRIPT_DIR"   # 書けなければ従来の場所
+SNAPSHOT_FILE="$_SNAP_DIR/.compact-snapshot"
 NOW=$(date '+%Y-%m-%d %H:%M')
 
 # git コンテキスト取得 (リポジトリ外でも安全に失敗)

--- a/hooks/pre-write-collision.sh
+++ b/hooks/pre-write-collision.sh
@@ -73,7 +73,19 @@ if ! git -C "$DIR" ls-files --error-unmatch "$FILE_PATH" >/dev/null 2>&1; then
   exit 0
 fi
 
-HOOK_REPO="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+# 検査対象のリポジトリ（= 利用者のプロジェクト）を解決する。
+#
+# ⚠️ plugin として配ると `$0` は **plugin のキャッシュ配下**になる（2026-09-10 実測）。
+#    `dirname "$0"/../..` を「リポジトリのルート」として使うと、設定もログも
+#    plugin の中を指す。設定は永久に見つからず、ログは全プロジェクトで共有される。
+#    兄弟ファイル（`_advisory-log.sh` 等）を引くのに `$0` を使うのは正しい。
+#    **プロジェクトを指したいときだけ**これを使う。
+_project_dir() {
+  if [ -n "${CLAUDE_PROJECT_DIR:-}" ]; then printf '%s' "$CLAUDE_PROJECT_DIR"; return; fi
+  git rev-parse --show-toplevel 2>/dev/null || pwd
+}
+
+HOOK_REPO="$(_project_dir)"
 # テストが実ログを退避して壊さずに縮退パスを検査できるよう、差し替え口だけ開ける。
 # 既定は従来どおりリポジトリ内のログ。
 LOG_DIR="${CLAUDE_TOOL_LOG_DIR:-${HOOK_REPO}/.claude/logs}"

--- a/hooks/review-gate.sh
+++ b/hooks/review-gate.sh
@@ -24,7 +24,19 @@ set -uo pipefail
 [ "${REVIEW_GATE_DISABLED:-0}" = "1" ] && exit 0
 
 # --- リポジトリルート解決（.claude/hooks/ の 2 つ上） ---
-ROOT="$(cd "$(dirname "$0")/../.." 2>/dev/null && pwd)" || exit 0
+# 検査対象のリポジトリ（= 利用者のプロジェクト）を解決する。
+#
+# ⚠️ plugin として配ると `$0` は **plugin のキャッシュ配下**になる（2026-09-10 実測）。
+#    `dirname "$0"/../..` を「リポジトリのルート」として使うと、設定もログも
+#    plugin の中を指す。設定は永久に見つからず、ログは全プロジェクトで共有される。
+#    兄弟ファイル（`_advisory-log.sh` 等）を引くのに `$0` を使うのは正しい。
+#    **プロジェクトを指したいときだけ**これを使う。
+_project_dir() {
+  if [ -n "${CLAUDE_PROJECT_DIR:-}" ]; then printf '%s' "$CLAUDE_PROJECT_DIR"; return; fi
+  git rev-parse --show-toplevel 2>/dev/null || pwd
+}
+
+ROOT="$(_project_dir)" || exit 0
 [ -n "$ROOT" ] || exit 0
 
 # --- sentinel: Wave1 が入った crew でのみ動く（他リポ/未整備は fail-open） ---


### PR DESCRIPTION
`i-Willink-LLC/willink-harness` から**一方向で export** した Core です。

| | |
|---|---|
| 追加 | 1 ファイル |
| 上書き | 68 ファイル |

**この範囲は正本が正本です。** ここを直接編集しても次の export で消えます。
直したいことがあれば正本へ issue / PR を立ててください（`CONTRIBUTING.md` 参照）。

## export 前にローカルで実走した検査

```
codex-sync            ✅
regression-suite      ✅
verify-harness（同梱）✅
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)