### PR TITLE
release: v2.7.0 — 同梱していた hook を実際に登録する

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,10 +10,10 @@
       "source": {
         "source": "url",
         "url": "https://github.com/willink-oss/willink-claude-kit.git",
-        "ref": "willink-claude-kit--v2.6.1"
+        "ref": "willink-claude-kit--v2.7.0"
       },
       "description": "標準サブエージェント 4 本 + 5 phase /build フローを束ねた開発キット。Generator-Verifier 分離・並列探索・project-standards 拡張・アクセシビリティを既定で設計する 3 層に対応。",
-      "version": "2.6.1",
+      "version": "2.7.0",
       "category": "development"
     }
   ]

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "willink-claude-kit",
-  "version": "2.6.1",
+  "version": "2.7.0",
   "description": "i-Willink 標準開発エージェント基盤。dev-explorer / dev-planner / dev-tester / dev-reviewer の 4 サブエージェント + 5 phase /build コマンドを Claude Code Plugin として提供。",
   "author": {
     "name": "i-Willink合同会社",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "willink-claude-kit",
-  "version": "2.6.1",
+  "version": "2.7.0",
   "description": "i-Willink 標準開発エージェント基盤を Codex でも使うための plugin。Claude Code 版を正本にし、Codex 向け adapter skill と同期チェックを提供する。",
   "author": {
     "name": "i-Willink合同会社",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,24 @@ All notable changes follow [Keep a Changelog](https://keepachangelog.com/en/1.1.
 
 ## [Unreleased]
 
+## [2.7.0] - 2026-09-10
+
+**Status**: 2.6.0 で同梱した hook **14 本が 1 本も登録されていなかった**のを直す。Claude Code の plugin は `hooks/hooks.json` を読んで登録する規約で、`hooks/*.sh` を置くだけでは効かない。本版で **10 本が実際に登録される**。
+
+### Added
+
+- **`hooks/hooks.json`** — 10 本を 5 イベントへ登録する。`PreToolUse`（`pre-bash-safety` / `pre-file-protect` / `pre-write-collision`）・`PostToolUse`（`post-commit-verify` / `post-file-eval` / `post-tool-log`）・`UserPromptSubmit`（`pre-status-verify-guard` / `review-gate`）・`PreCompact`（`pre-compact-snapshot`）・`InstructionsLoaded`（`instructions-loaded-log`）。
+  - **同梱するが登録しない 4 本**: `pre-commit-quality.sh` / `pre-commit-shell-lint.sh` / `pre-commit-silent-zero.sh` は **git の pre-commit hook** で Claude Code のイベントには載らない（`.git/hooks/pre-commit` から呼ぶ）。`_advisory-log.sh` は共有ライブラリ。
+  - **止めるのは PreToolUse の 3 本だけ**。残る 7 本は fail-open で、`review-gate` は設定ファイルが無ければ通す。直 push を許すリポは `HARNESS_DIRECT_PUSH_REPOS`（カンマ区切り・**既定は空 = 常に PR を要求**）。
+
+### Fixed
+
+- **plugin 配下で `$0` が plugin のキャッシュを指す問題**。`dirname "$0"/../..` を「リポジトリのルート」として使っていた 4 本を、`CLAUDE_PROJECT_DIR`（無ければ `git rev-parse --show-toplevel`、それも無ければ `pwd`）に統一した。従来は `review-gate` が**利用者の設定を永久に見つけず**、`pre-write-collision` のログと `pre-compact-snapshot` のスナップショットが**全プロジェクトで共有**され、`pre-bash-safety` が毎 commit で警告を出し続ける状態だった。兄弟ファイルを `$0` から引くのは正しい用途なのでそのまま。
+
+### 検査
+
+`docs/harness/wiring.md` に plugin 配布の節（登録表・止める 3 本の既定・パスの前提）を追加。正本リポ側に `scripts/test-plugin-hooks.sh`（11 件）が入り、登録漏れ・`$0` からのプロジェクト推測・スナップショットの置き場所を CI で止める。
+
 ## [2.6.1] - 2026-09-10
 
 **Status**: `scripts/check-kit-enabled.sh`（doctor）が **hooks を数えず、旧版を HEALTHY と報告していた**のを直す。2.6.0 で hooks を初搭載したが、doctor は 162 行のうち hook への言及が 0 行だった。機能追加なし・破壊的変更なし。

--- a/codex/sync-manifest.json
+++ b/codex/sync-manifest.json
@@ -5,7 +5,7 @@
   "canonicalFiles": [
     {
       "path": ".claude-plugin/plugin.json",
-      "sha256": "8edfda65b057ba3759c501a32e476fd2314dc14ef78f4842da53c417fa23179e",
+      "sha256": "463b89b2d194cdc6d2dbe9c7dc9c3a227e5a1961939f6e627ecf0f21922f7e55",
       "codexAdapters": [
         ".codex-plugin/plugin.json",
         "skills/codex-build/SKILL.md"
@@ -16,7 +16,7 @@
     },
     {
       "path": ".claude-plugin/marketplace.json",
-      "sha256": "ed2fcf80ce2c4bef88e337d9de596eebf189b408f4ee27ab46f19cec98cade56",
+      "sha256": "d9864f734c7a6525ff9ed66ee7a3347c70ac8571aa310605346ff6ad72f440c3",
       "codexAdapters": [
         ".codex-plugin/plugin.json",
         "skills/codex-build/SKILL.md"


### PR DESCRIPTION
2.6.0 は hook を **14 本配りましたが、1 本も登録されていませんでした**。Claude Code の plugin は `hooks/hooks.json` を読む規約で、`hooks/*.sh` を置くだけでは効きません。

本版で **10 本が 5 イベントへ登録**されます。

| イベント | 本数 | 既定 |
|---|---|---|
| `PreToolUse` | 3 | **止める** |
| `PostToolUse` | 3 | fail-open |
| `UserPromptSubmit` | 2 | fail-open（`review-gate` は設定が無ければ通す） |
| `PreCompact` | 1 | fail-open |
| `InstructionsLoaded` | 1 | fail-open |

**同梱するが登録しない 4 本** — `pre-commit-*` 3 本は git の pre-commit hook、`_advisory-log.sh` は共有ライブラリです。

あわせて plugin 配下で `$0` が plugin のキャッシュを指す問題を `CLAUDE_PROJECT_DIR` 基準に直しました（従来は `review-gate` が利用者の設定を永久に見つけず、ログとスナップショットが全プロジェクトで共有されていました）。

実測: `check_sync.py --check` PASS / regression-suite **22 ファイル 0 失敗**。

🤖 Generated with [Claude Code](https://claude.com/claude-code)